### PR TITLE
feat(network): add outgoing connection support to Node

### DIFF
--- a/src/main/java/com/blocksmith/network/Peer.java
+++ b/src/main/java/com/blocksmith/network/Peer.java
@@ -280,6 +280,20 @@ public class Peer {
     }
 
     /**
+     * Returns the socket's output stream.
+     * Used by Node to create MessageContext for outbound peer handlers.
+     *
+     * @return the socket's output stream
+     * @throws IOException if stream cannot be obtained
+     */
+    public java.io.OutputStream getOutputStream() throws IOException {
+        if (!connected || socket == null) {
+            throw new IllegalStateException("Not connected");
+        }
+        return socket.getOutputStream();
+    }
+
+    /**
      * Sets the remote node ID (called after handshake).
      */
     public void setRemoteNodeId(String remoteNodeId) {


### PR DESCRIPTION
Node.connectToPeer(host, port) initiates outbound connections with duplicate/MAX_PEERS checks, PeerManager registration, and message listener with handler dispatch. Added Peer.getOutputStream() for MessageContext creation. Outbound peers cleaned up in Node.stop().

Closes #56