### PR TITLE
Sprint 9c: heartbeat dead-peer detection and eviction

### DIFF
--- a/.ai/STATUS.md
+++ b/.ai/STATUS.md
@@ -10,8 +10,8 @@
 |-------|-------|
 | **Phase** | 2 - Network Layer |
 | **Current Sprint** | 9 (Node Discovery) |
-| **Current Milestone** | 9b Pending (PeerManager) |
-| **Status** | Milestone 9a complete, starting 9b |
+| **Current Milestone** | 9c Complete (Heartbeat) |
+| **Status** | Milestones 9a-9c complete, 9d pending (Peer Discovery) |
 
 ---
 
@@ -42,7 +42,7 @@ Phase 1: Core Blockchain     [███████████████] 100
 
 Phase 2: Network Layer       [████████░░░░░░░] 50% ← CURRENT
 ├── Sprint 8: P2P Networking ✅ COMPLETE (8a ✅, 8b ✅, 8c ✅, 8d ✅)
-├── Sprint 9: Node Discovery 🔄 ← CURRENT (9a ✅, 9b pending)
+├── Sprint 9: Node Discovery 🔄 ← CURRENT (9a ✅, 9b ✅, 9c ✅, 9d pending)
 ├── Sprint 10: Broadcasting  ⬜
 └── Sprint 11: Mempool Sync  ⬜
 ```
@@ -64,7 +64,9 @@ Phase 2: Network Layer       [████████░░░░░░░] 50%
 | PeerTest | 7 | ✅ |
 | CommunicationTest | 6 | ✅ |
 | PeerInfoTest | 6 | ✅ |
-| **Total** | **120** | ✅ |
+| PeerManagerTest | 8 | ✅ |
+| HeartbeatTest | 4 | ✅ |
+| **Total** | **132** | ✅ |
 
 Last test run: `mvn test` - All passing
 
@@ -96,7 +98,7 @@ Last test run: `mvn test` - All passing
 | MessageType.java | ✅ Complete | ~45 | Message types enum |
 | Message.java | ✅ Complete | ~82 | Base message class |
 | NetworkConfig.java | ✅ Complete | ~59 | Network constants |
-| Node.java | ✅ Complete | ~285 | Server + message loop + handler registry |
+| Node.java | ✅ Complete | ~510 | Server + message loop + peer tracking + heartbeat eviction |
 | Peer.java | ✅ Complete | ~294 | Client + async listener thread |
 | MessageParser.java | ✅ Complete | ~116 | JSON-to-Message routing (Sprint 8d) |
 | MessageHandler.java | ✅ Complete | ~36 | Handler functional interface (Sprint 8d) |
@@ -104,6 +106,7 @@ Last test run: `mvn test` - All passing
 | MessageListener.java | ✅ Complete | ~43 | Async listener interface (Sprint 8d) |
 | PeerState.java | ✅ Complete | ~43 | Peer connection lifecycle enum (Sprint 9a) |
 | PeerInfo.java | ✅ Complete | ~110 | Peer metadata tracking (Sprint 9a) |
+| PeerManager.java | ✅ Complete | ~145 | Peer registry, MAX_PEERS enforcement (Sprint 9b) |
 | messages/*.java | ✅ Complete | ~150 | 5 concrete message types |
 
 ### Demo
@@ -147,6 +150,10 @@ Last test run: `mvn test` - All passing
 - [x] Bidirectional message exchange (Sprint 8d)
 - [x] PeerState enum for connection lifecycle (Sprint 9a)
 - [x] PeerInfo class for peer metadata tracking (Sprint 9a)
+- [x] PeerManager registry with MAX_PEERS enforcement (Sprint 9b)
+- [x] Node peer tracking + outgoing connections (connectToPeer) (Sprint 9b)
+- [x] Heartbeat PING scheduler + PONG handling (Sprint 9c)
+- [x] Dead peer detection and eviction on timeout (Sprint 9c)
 
 ---
 
@@ -154,8 +161,8 @@ Last test run: `mvn test` - All passing
 
 | Item | Value |
 |------|-------|
-| **Current Branch** | `master` |
-| **Last Commit** | Milestone 9a complete (PeerInfo) |
+| **Current Branch** | `sprint9c/heartbeat` |
+| **Last Commit** | Milestone 9c complete (heartbeat eviction + tests) |
 | **Tag** | `v1.0.0` (Phase 1) |
 | **Main Branch** | `master` |
 
@@ -170,16 +177,15 @@ _None currently._
 ## 📝 Notes for Next Session
 
 1. **Sprint 9 IN PROGRESS** - Node Discovery
-   - Milestone 9a complete (2026-02-10)
-   - 3 milestones remaining: 9b (PeerManager), 9c (Heartbeat), 9d (Peer Discovery)
-   - 12 issues remaining (#50-#61)
+   - Milestones 9a, 9b, 9c complete
+   - 1 milestone remaining: 9d (Peer Discovery)
 
-2. **Next: Milestone 9b** - PeerManager + Node Integration
-   - PeerManager class (#50)
-   - Integrate PeerManager into Node (#51)
-   - Outgoing connection support (#52)
-   - Tests (#53)
+2. **Next: Milestone 9d** - Peer Discovery
+   - GetPeersMessage and PeersMessage classes
+   - GET_PEERS and PEERS handlers in Node
+   - Seed nodes config + bootstrap on startup
+   - Unit tests for peer discovery
 
 ---
 
-*Last updated: 2026-02-10 | Milestone 9a Complete*
+*Last updated: 2026-06-30 | Milestone 9c Complete*

--- a/.ai/sprints/sprint9/sprint-log.md
+++ b/.ai/sprints/sprint9/sprint-log.md
@@ -27,11 +27,42 @@
 
 ---
 
-## Milestone 9b: PeerManager + Node Integration - Pending
+## Milestone 9b: PeerManager + Node Integration - ✅ Complete (2026-02-14)
+
+### Delivered
+- `PeerManager.java` - Peer registry backed by ConcurrentHashMap, enforces MAX_PEERS for CONNECTED peers
+- Node integration - registers peers after handshake, removes on disconnect
+- `Node.connectToPeer(host, port)` - outgoing connection support
+- `PeerManagerTest.java` - 8 unit tests
+
+### Issues Closed
+- #54: Create PeerManager class ✅
+- #55: Integrate PeerManager into Node ✅
+- #56: Add outgoing connection support (connectToPeer) ✅
+- #57: Unit tests for PeerManager and Node peer tracking ✅
+
+### Stats
+- Tests added: 8 (total: 128)
 
 ---
 
-## Milestone 9c: Heartbeat - Pending
+## Milestone 9c: Heartbeat - ✅ Complete (2026-06-30)
+
+### Delivered
+- `HEARTBEAT_INTERVAL_MS` and `PEER_TIMEOUT_MS` constants in NetworkConfig
+- ScheduledExecutorService in Node sends periodic PINGs to connected peers
+- PONG handler; lastSeen updated on every received message
+- Dead peer detection and eviction in heartbeatTask (evict-then-ping): peers past PEER_TIMEOUT_MS are removed from the registry, their writer closed
+- `HeartbeatTest.java` - 4 unit tests (eviction, live-peer retention, mixed eviction, config invariant)
+
+### Issues Closed
+- #61: Add heartbeat constants to NetworkConfig ✅
+- #62: Implement heartbeat scheduler in Node ✅
+- #63: Implement dead peer detection and eviction ✅
+- #64: Unit tests for heartbeat mechanism ✅
+
+### Stats
+- Tests added: 4 (total: 132)
 
 ---
 

--- a/src/main/java/com/blocksmith/network/Node.java
+++ b/src/main/java/com/blocksmith/network/Node.java
@@ -160,9 +160,20 @@ public class Node {
     private void heartbeatTask() {
         PingMessage ping = new PingMessage(nodeId);
         String pingJson = ping.toJson();
+        long now = System.currentTimeMillis();
 
         for (PeerInfo peer : peerManager.getConnectedPeers()) {
-            PrintWriter writer = peerWriters.get(peer.getAddress());
+            String address = peer.getAddress();
+
+            if (now - peer.getLastSeen() > NetworkConfig.PEER_TIMEOUT_MS) {
+                peerManager.removePeer(address);
+                PrintWriter deadWriter = peerWriters.remove(address);
+                if (deadWriter != null) deadWriter.close();
+                System.out.println("  ✗ Evicted dead peer " + address);
+                continue;
+            }
+
+            PrintWriter writer = peerWriters.get(address);
             if (writer != null) writer.println(pingJson);
         }
     }

--- a/src/test/java/com/blocksmith/network/HeartbeatTest.java
+++ b/src/test/java/com/blocksmith/network/HeartbeatTest.java
@@ -1,0 +1,118 @@
+package com.blocksmith.network;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the heartbeat mechanism in Node - dead peer detection and eviction.
+ *
+ * The node is created but never started: heartbeatTask() only reads nodeId,
+ * peerManager, and peerWriters, all available without binding a socket. This
+ * keeps the tests free of ports and real timing.
+ */
+@DisplayName("Heartbeat Tests")
+class HeartbeatTest {
+
+    private Node node;
+
+    private static final int TEST_PORT_BASE = 19500;
+    private static int portCounter = 0;
+
+    private int getNextPort() {
+        return TEST_PORT_BASE + (portCounter++);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (node != null) {
+            node.stop();
+        }
+    }
+
+    // ===== REFLECTION HELPERS =====
+
+    /** Invokes the private heartbeatTask() one time. */
+    private void runHeartbeat(Node target) throws Exception {
+        Method task = Node.class.getDeclaredMethod("heartbeatTask");
+        task.setAccessible(true);
+        task.invoke(target);
+    }
+
+    /** Forces a peer's lastSeen to a specific timestamp (no public setter exists). */
+    private void setLastSeen(PeerInfo peer, long millis) throws Exception {
+        Field lastSeen = PeerInfo.class.getDeclaredField("lastSeen");
+        lastSeen.setAccessible(true);
+        lastSeen.setLong(peer, millis);
+    }
+
+    private PeerInfo connectedPeer(String host, int port, String nodeId) {
+        PeerInfo peer = new PeerInfo(host, port);
+        peer.markConnected(nodeId);
+        return peer;
+    }
+
+    // ===== EVICTION TESTS =====
+
+    @Test
+    @DisplayName("heartbeat evicts peer whose lastSeen exceeds PEER_TIMEOUT_MS")
+    void heartbeat_evictsDeadPeer() throws Exception {
+        node = new Node(getNextPort());
+        PeerInfo dead = connectedPeer("10.0.0.1", 9001, "node-dead");
+        setLastSeen(dead, System.currentTimeMillis() - NetworkConfig.PEER_TIMEOUT_MS - 1000);
+        node.getPeerManager().addPeer(dead);
+
+        runHeartbeat(node);
+
+        assertFalse(node.getPeerManager().isKnown("10.0.0.1:9001"),
+                "Peer past the timeout should be evicted");
+    }
+
+    @Test
+    @DisplayName("heartbeat keeps peer seen within PEER_TIMEOUT_MS")
+    void heartbeat_keepsLivePeer() throws Exception {
+        node = new Node(getNextPort());
+        PeerInfo live = connectedPeer("10.0.0.2", 9002, "node-live");
+        node.getPeerManager().addPeer(live);
+
+        runHeartbeat(node);
+
+        assertTrue(node.getPeerManager().isKnown("10.0.0.2:9002"),
+                "Recently seen peer should not be evicted");
+    }
+
+    @Test
+    @DisplayName("heartbeat evicts only stale peers, keeps live ones")
+    void heartbeat_evictsOnlyStalePeers() throws Exception {
+        node = new Node(getNextPort());
+        PeerInfo dead = connectedPeer("10.0.0.3", 9003, "node-dead");
+        setLastSeen(dead, System.currentTimeMillis() - NetworkConfig.PEER_TIMEOUT_MS - 1000);
+        PeerInfo live = connectedPeer("10.0.0.4", 9004, "node-live");
+
+        node.getPeerManager().addPeer(dead);
+        node.getPeerManager().addPeer(live);
+
+        runHeartbeat(node);
+
+        assertFalse(node.getPeerManager().isKnown("10.0.0.3:9003"),
+                "Stale peer should be evicted");
+        assertTrue(node.getPeerManager().isKnown("10.0.0.4:9004"),
+                "Live peer should remain");
+        assertEquals(1, node.getPeerManager().getConnectedCount(),
+                "Only the live peer should remain connected");
+    }
+
+    // ===== CONFIG INVARIANT =====
+
+    @Test
+    @DisplayName("peer timeout must exceed the heartbeat interval")
+    void heartbeatConfig_timeoutLongerThanInterval() {
+        assertTrue(NetworkConfig.PEER_TIMEOUT_MS > NetworkConfig.HEARTBEAT_INTERVAL_MS,
+                "A peer must be pinged at least once before it can time out");
+    }
+}


### PR DESCRIPTION
## Summary
Completes milestone 9c (Heartbeat) of Sprint 9 (Node Discovery).

- **Eviction** (#63): `heartbeatTask()` now evicts before pinging — peers whose `lastSeen` exceeds `PEER_TIMEOUT_MS` are removed from the registry and their writer closed, then PINGs go to survivors.
- **Tests** (#64): new `HeartbeatTest` with 4 cases — dead-peer eviction, live-peer retention, mixed eviction (only stale removed), and the `PEER_TIMEOUT_MS > HEARTBEAT_INTERVAL_MS` config invariant.
- **Docs**: STATUS.md and sprint-log.md updated to mark milestones 9b and 9c complete.

Tests are reflection-driven (invoke the private `heartbeatTask()`, set `PeerInfo.lastSeen`) and run against an unstarted Node, so no sockets, ports, or `Thread.sleep` — no timing flakiness.

## Test plan
- [x] `mvn test` — 132 tests pass, BUILD SUCCESS
- [x] `mvn test -Dtest=HeartbeatTest` — 4/4 pass
- [x] Clean compile

Closes #63, closes #64.