### PR TITLE
Sprint 9d: peer discovery (GET_PEERS/PEERS, seed bootstrap)

### DIFF
--- a/src/main/java/com/blocksmith/network/MessageParser.java
+++ b/src/main/java/com/blocksmith/network/MessageParser.java
@@ -3,9 +3,11 @@ package com.blocksmith.network;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.blocksmith.network.messages.GetPeersMessage;
 import com.blocksmith.network.messages.HelloMessage;
 import com.blocksmith.network.messages.NewBlockMessage;
 import com.blocksmith.network.messages.NewTransactionMessage;
+import com.blocksmith.network.messages.PeersMessage;
 import com.blocksmith.network.messages.PingMessage;
 import com.blocksmith.network.messages.PongMessage;
 import com.google.gson.JsonObject;
@@ -50,7 +52,9 @@ public class MessageParser {
         TYPE_REGISTRY.put(MessageType.PING, PingMessage.class);
         TYPE_REGISTRY.put(MessageType.PONG, PongMessage.class);
         TYPE_REGISTRY.put(MessageType.NEW_BLOCK, NewBlockMessage.class);
-        TYPE_REGISTRY.put(MessageType.NEW_TRANSACTION, NewTransactionMessage.class);        
+        TYPE_REGISTRY.put(MessageType.NEW_TRANSACTION, NewTransactionMessage.class);
+        TYPE_REGISTRY.put(MessageType.GET_PEERS, GetPeersMessage.class);
+        TYPE_REGISTRY.put(MessageType.PEERS, PeersMessage.class);
     }
 
     /**

--- a/src/main/java/com/blocksmith/network/NetworkConfig.java
+++ b/src/main/java/com/blocksmith/network/NetworkConfig.java
@@ -1,5 +1,7 @@
 package com.blocksmith.network;
 
+import java.util.List;
+
 /**
  * THEORY: Network Configuration Constants
  * 
@@ -82,7 +84,20 @@ public class NetworkConfig {
      */
     public static final int PEER_TIMEOUT_MS = 30000;
 
-    
+    /**
+     * THEORY: Seed Nodes - Bootstrapping the Network
+     *
+     * A fresh node knows no peers. It connects to a hard-coded list of
+     * "seed nodes" to get its first connections, then peer discovery
+     * (GET_PEERS / PEERS) grows the network from there. Bitcoin uses DNS
+     * seeds for the same purpose.
+     *
+     * Format: "host:port". Empty by default - populate for a real network
+     * or for local multi-node testing, e.g. List.of("localhost:8335").
+     */
+    public static final List<String> SEED_NODES = List.of();
+
+
     // Private constructor - utility class, no instances needed
     private NetworkConfig() {}
 }

--- a/src/main/java/com/blocksmith/network/Node.java
+++ b/src/main/java/com/blocksmith/network/Node.java
@@ -149,6 +149,33 @@ public class Node {
             TimeUnit.MILLISECONDS);        
         
         System.out.println("▶ Node " + nodeId + " started on port " + port);
+
+        bootstrap();
+    }
+
+    /**
+     * THEORY: Bootstrap - Joining the Network
+     *
+     * On startup a node has no peers. It connects to the configured seed
+     * nodes to get its first connections; peer discovery (GET_PEERS) then
+     * grows the network from there.
+     *
+     * Best-effort: a seed that is unreachable or is ourselves is skipped,
+     * never fatal to startup.
+     */
+    private void bootstrap() {
+        for (String address : NetworkConfig.SEED_NODES) {
+            PeerInfo seed = parseAddress(address);
+            if (seed == null) continue;
+            if (seed.getPort() == port) continue; // skip self (local testing)
+            try {
+                connectToPeer(seed.getHost(), seed.getPort());
+                System.out.println("  ✓ Bootstrapped to seed " + address);
+            } catch (Exception e) {
+                System.out.println("  ✗ Could not reach seed " + address
+                        + ": " + e.getMessage());
+            }
+        }
     }
 
     /**

--- a/src/main/java/com/blocksmith/network/Node.java
+++ b/src/main/java/com/blocksmith/network/Node.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import com.blocksmith.network.messages.PongMessage;
 import com.blocksmith.network.messages.HelloMessage;
 import com.blocksmith.network.messages.PingMessage;
+import com.blocksmith.network.messages.PeersMessage;
 
 /**
  * THEORY: Network Node - The Heart of P2P
@@ -246,6 +247,49 @@ public class Node {
         registerHandler(MessageType.PONG, (message, context) -> {
             System.out.println("  ← Received PONG from " + context.getRemoteNodeId());
         });
+
+        // GET_PEERS -> respond with the addresses of all known peers
+        registerHandler(MessageType.GET_PEERS, (message, context) -> {
+            List<String> addresses = peerManager.getKnownPeers().stream()
+                    .map(PeerInfo::getAddress)
+                    .toList();
+            context.sendMessage(new PeersMessage(nodeId, addresses));
+            System.out.println("  → Sent PEERS (" + addresses.size() + ") to "
+                    + context.getRemoteNodeId());
+        });
+
+        // PEERS -> record received addresses as DISCOVERED peers (no auto-connect)
+        registerHandler(MessageType.PEERS, (message, context) -> {
+            List<String> received = ((PeersMessage) message).getPeers();
+            if (received == null) return;
+
+            int added = 0;
+            for (String address : received) {
+                PeerInfo info = parseAddress(address);
+                if (info != null && peerManager.addPeer(info)) added++;
+            }
+            System.out.println("  ← Received PEERS (" + received.size() + "), added "
+                    + added + " new");
+        });
+    }
+
+    /**
+     * Parses a "host:port" address into a DISCOVERED PeerInfo.
+     * Splits on the last colon so IPv4 hosts parse cleanly.
+     *
+     * @return PeerInfo, or null if the address is malformed
+     */
+    private PeerInfo parseAddress(String address) {
+        if (address == null) return null;
+        int idx = address.lastIndexOf(':');
+        if (idx <= 0 || idx == address.length() - 1) return null;
+        try {
+            String host = address.substring(0, idx);
+            int port = Integer.parseInt(address.substring(idx + 1));
+            return new PeerInfo(host, port);
+        } catch (NumberFormatException e) {
+            return null;
+        }
     }
 
     /**

--- a/src/main/java/com/blocksmith/network/messages/GetPeersMessage.java
+++ b/src/main/java/com/blocksmith/network/messages/GetPeersMessage.java
@@ -1,0 +1,18 @@
+package com.blocksmith.network.messages;
+
+import com.blocksmith.network.Message;
+import com.blocksmith.network.MessageType;
+
+/**
+ * Peer discovery request: "Who else do you know?"
+ * The receiver replies with a PeersMessage listing its known peers.
+ */
+public class GetPeersMessage extends Message {
+
+    public GetPeersMessage(String nodeId) {
+        super(MessageType.GET_PEERS, nodeId);
+    }
+
+    /** Default constructor for Gson. */
+    public GetPeersMessage() {}
+}

--- a/src/main/java/com/blocksmith/network/messages/PeersMessage.java
+++ b/src/main/java/com/blocksmith/network/messages/PeersMessage.java
@@ -1,0 +1,25 @@
+package com.blocksmith.network.messages;
+
+import java.util.List;
+
+import com.blocksmith.network.Message;
+import com.blocksmith.network.MessageType;
+
+/**
+ * Peer discovery response carrying known peer addresses in "host:port" format.
+ * Sent in reply to a GetPeersMessage.
+ */
+public class PeersMessage extends Message {
+
+    private List<String> peers;
+
+    public PeersMessage(String nodeId, List<String> peers) {
+        super(MessageType.PEERS, nodeId);
+        this.peers = peers;
+    }
+
+    /** Default constructor for Gson. */
+    public PeersMessage() {}
+
+    public List<String> getPeers() { return peers; }
+}

--- a/src/test/java/com/blocksmith/network/PeerDiscoveryTest.java
+++ b/src/test/java/com/blocksmith/network/PeerDiscoveryTest.java
@@ -1,0 +1,144 @@
+package com.blocksmith.network;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+
+import com.blocksmith.network.messages.GetPeersMessage;
+import com.blocksmith.network.messages.PeersMessage;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for peer discovery - GetPeersMessage/PeersMessage serialization and
+ * the GET_PEERS / PEERS handlers in Node.
+ *
+ * Handlers are registered in the Node constructor, so the node is never
+ * started: tests pull the handler out of the registry by reflection and
+ * drive it directly with an in-memory MessageContext.
+ */
+@DisplayName("Peer Discovery Tests")
+class PeerDiscoveryTest {
+
+    private Node node;
+
+    private static final int TEST_PORT_BASE = 19600;
+    private static int portCounter = 0;
+
+    private int getNextPort() {
+        return TEST_PORT_BASE + (portCounter++);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (node != null) {
+            node.stop();
+        }
+    }
+
+    // ===== REFLECTION HELPER =====
+
+    @SuppressWarnings("unchecked")
+    private MessageHandler getHandler(Node target, MessageType type) throws Exception {
+        Field handlersField = Node.class.getDeclaredField("handlers");
+        handlersField.setAccessible(true);
+        Map<MessageType, MessageHandler> handlers =
+                (Map<MessageType, MessageHandler>) handlersField.get(target);
+        return handlers.get(type);
+    }
+
+    private PeerInfo connectedPeer(String host, int port, String nodeId) {
+        PeerInfo peer = new PeerInfo(host, port);
+        peer.markConnected(nodeId);
+        return peer;
+    }
+
+    // ===== SERIALIZATION TESTS =====
+
+    @Test
+    @DisplayName("GetPeersMessage round-trips through MessageParser")
+    void getPeersMessage_parsesToCorrectType() {
+        String json = new GetPeersMessage("node-123").toJson();
+
+        Message parsed = MessageParser.parse(json);
+
+        assertInstanceOf(GetPeersMessage.class, parsed, "Should parse as GetPeersMessage");
+        assertEquals(MessageType.GET_PEERS, parsed.getType());
+        assertEquals("node-123", parsed.getNodeId());
+    }
+
+    @Test
+    @DisplayName("PeersMessage round-trips its peer list through MessageParser")
+    void peersMessage_preservesPeerList() {
+        List<String> addresses = List.of("10.0.0.1:8335", "10.0.0.2:8335");
+        String json = new PeersMessage("node-123", addresses).toJson();
+
+        Message parsed = MessageParser.parse(json);
+
+        assertInstanceOf(PeersMessage.class, parsed, "Should parse as PeersMessage");
+        assertEquals(addresses, ((PeersMessage) parsed).getPeers(),
+                "Peer list should survive the round trip");
+    }
+
+    // ===== GET_PEERS HANDLER =====
+
+    @Test
+    @DisplayName("GET_PEERS handler responds with known peer addresses")
+    void getPeersHandler_respondsWithKnownPeers() throws Exception {
+        node = new Node(getNextPort());
+        node.getPeerManager().addPeer(connectedPeer("10.0.0.1", 8335, "node-a"));
+        node.getPeerManager().addPeer(connectedPeer("10.0.0.2", 8335, "node-b"));
+
+        StringWriter sink = new StringWriter();
+        MessageContext ctx = new MessageContext(new PrintWriter(sink, true), "requester");
+        getHandler(node, MessageType.GET_PEERS)
+                .handle(new GetPeersMessage("requester"), ctx);
+
+        Message response = MessageParser.parse(sink.toString().trim());
+        assertInstanceOf(PeersMessage.class, response, "Reply should be a PeersMessage");
+        List<String> peers = ((PeersMessage) response).getPeers();
+        assertTrue(peers.contains("10.0.0.1:8335"), "Reply should include first peer");
+        assertTrue(peers.contains("10.0.0.2:8335"), "Reply should include second peer");
+    }
+
+    // ===== PEERS HANDLER =====
+
+    @Test
+    @DisplayName("PEERS handler records received addresses as DISCOVERED")
+    void peersHandler_addsReceivedPeers() throws Exception {
+        node = new Node(getNextPort());
+        PeersMessage incoming = new PeersMessage("sender",
+                List.of("10.0.0.5:8335", "10.0.0.6:8335"));
+
+        MessageContext ctx = new MessageContext(new PrintWriter(new StringWriter()), "sender");
+        getHandler(node, MessageType.PEERS).handle(incoming, ctx);
+
+        PeerManager pm = node.getPeerManager();
+        assertTrue(pm.isKnown("10.0.0.5:8335"), "First received peer should be recorded");
+        assertTrue(pm.isKnown("10.0.0.6:8335"), "Second received peer should be recorded");
+        assertEquals(PeerState.DISCOVERED, pm.getPeer("10.0.0.5:8335").getState(),
+                "Recorded peer should be DISCOVERED, not CONNECTED");
+    }
+
+    @Test
+    @DisplayName("PEERS handler skips malformed addresses")
+    void peersHandler_skipsMalformedAddresses() throws Exception {
+        node = new Node(getNextPort());
+        PeersMessage incoming = new PeersMessage("sender",
+                List.of("garbage", "10.0.0.7:8335", "noport:"));
+
+        MessageContext ctx = new MessageContext(new PrintWriter(new StringWriter()), "sender");
+        getHandler(node, MessageType.PEERS).handle(incoming, ctx);
+
+        PeerManager pm = node.getPeerManager();
+        assertTrue(pm.isKnown("10.0.0.7:8335"), "Valid address should be recorded");
+        assertFalse(pm.isKnown("garbage"), "Malformed address should be skipped");
+        assertEquals(1, pm.getKnownPeers().size(), "Only the valid address should be recorded");
+    }
+}


### PR DESCRIPTION
## Summary
Completes milestone 9d (Peer Discovery), the final milestone of Sprint 9.

- **Messages** (#68): `GetPeersMessage` (request) and `PeersMessage` (carries `List<String>` of `host:port`), both registered in `MessageParser` so they parse off the wire.
- **Handlers** (#69): GET_PEERS replies with known peer addresses; PEERS records received addresses as `DISCOVERED`. Deliberately **record-only — no auto-connect** (keeps the handler focused; connecting stays explicit via bootstrap/`connectToPeer`).
- **Bootstrap** (#70): `SEED_NODES` in NetworkConfig (empty by default) + best-effort `bootstrap()` on `Node.start()` — skips self and tolerates unreachable seeds without failing startup.
- **Tests** (#71): `PeerDiscoveryTest`, 5 tests — message round-trips, both handlers, malformed-address skipping. Reflection-driven against an unstarted node (no sockets).

## Notes / follow-ups
- Gossip-driven **auto-connect** is intentionally deferred (needs MAX_PEERS guarding); natural Sprint 10 lead-in.
- No self-identification filtering in gossip yet — harmless while connect is explicit.

## Test plan
- [x] `mvn test` — 137 tests pass, BUILD SUCCESS
- [x] `mvn test -Dtest=PeerDiscoveryTest` — 5/5 pass
- [x] Clean compile

Closes #68, closes #69, closes #70, closes #71.