### PR TITLE
docs: mark Sprint 9 (Node Discovery) complete

### DIFF
--- a/.ai/STATUS.md
+++ b/.ai/STATUS.md
@@ -9,9 +9,9 @@
 | Field | Value |
 |-------|-------|
 | **Phase** | 2 - Network Layer |
-| **Current Sprint** | 9 (Node Discovery) |
-| **Current Milestone** | 9c Complete (Heartbeat) |
-| **Status** | Milestones 9a-9c complete, 9d pending (Peer Discovery) |
+| **Current Sprint** | 9 (Node Discovery) - Complete |
+| **Current Milestone** | 9d Complete (Peer Discovery) |
+| **Status** | Sprint 9 complete (9a-9d), next: Sprint 10 (Broadcasting) |
 
 ---
 
@@ -42,8 +42,8 @@ Phase 1: Core Blockchain     [███████████████] 100
 
 Phase 2: Network Layer       [████████░░░░░░░] 50% ← CURRENT
 ├── Sprint 8: P2P Networking ✅ COMPLETE (8a ✅, 8b ✅, 8c ✅, 8d ✅)
-├── Sprint 9: Node Discovery 🔄 ← CURRENT (9a ✅, 9b ✅, 9c ✅, 9d pending)
-├── Sprint 10: Broadcasting  ⬜
+├── Sprint 9: Node Discovery ✅ COMPLETE (9a ✅, 9b ✅, 9c ✅, 9d ✅)
+├── Sprint 10: Broadcasting  ⬜ ← NEXT
 └── Sprint 11: Mempool Sync  ⬜
 ```
 
@@ -66,7 +66,8 @@ Phase 2: Network Layer       [████████░░░░░░░] 50%
 | PeerInfoTest | 6 | ✅ |
 | PeerManagerTest | 8 | ✅ |
 | HeartbeatTest | 4 | ✅ |
-| **Total** | **132** | ✅ |
+| PeerDiscoveryTest | 5 | ✅ |
+| **Total** | **137** | ✅ |
 
 Last test run: `mvn test` - All passing
 
@@ -97,8 +98,8 @@ Last test run: `mvn test` - All passing
 |-------|--------|-------|-------|
 | MessageType.java | ✅ Complete | ~45 | Message types enum |
 | Message.java | ✅ Complete | ~82 | Base message class |
-| NetworkConfig.java | ✅ Complete | ~59 | Network constants |
-| Node.java | ✅ Complete | ~510 | Server + message loop + peer tracking + heartbeat eviction |
+| NetworkConfig.java | ✅ Complete | ~103 | Network constants + heartbeat + seed nodes |
+| Node.java | ✅ Complete | ~560 | Server + message loop + peer tracking + heartbeat eviction + peer discovery + seed bootstrap |
 | Peer.java | ✅ Complete | ~294 | Client + async listener thread |
 | MessageParser.java | ✅ Complete | ~116 | JSON-to-Message routing (Sprint 8d) |
 | MessageHandler.java | ✅ Complete | ~36 | Handler functional interface (Sprint 8d) |
@@ -107,7 +108,7 @@ Last test run: `mvn test` - All passing
 | PeerState.java | ✅ Complete | ~43 | Peer connection lifecycle enum (Sprint 9a) |
 | PeerInfo.java | ✅ Complete | ~110 | Peer metadata tracking (Sprint 9a) |
 | PeerManager.java | ✅ Complete | ~145 | Peer registry, MAX_PEERS enforcement (Sprint 9b) |
-| messages/*.java | ✅ Complete | ~150 | 5 concrete message types |
+| messages/*.java | ✅ Complete | ~180 | 7 concrete message types (+ GetPeers/Peers, Sprint 9d) |
 
 ### Demo
 
@@ -154,6 +155,9 @@ Last test run: `mvn test` - All passing
 - [x] Node peer tracking + outgoing connections (connectToPeer) (Sprint 9b)
 - [x] Heartbeat PING scheduler + PONG handling (Sprint 9c)
 - [x] Dead peer detection and eviction on timeout (Sprint 9c)
+- [x] GetPeersMessage / PeersMessage for peer discovery gossip (Sprint 9d)
+- [x] GET_PEERS / PEERS handlers in Node (Sprint 9d)
+- [x] Seed-node config + bootstrap on startup (Sprint 9d)
 
 ---
 
@@ -161,8 +165,8 @@ Last test run: `mvn test` - All passing
 
 | Item | Value |
 |------|-------|
-| **Current Branch** | `sprint9c/heartbeat` |
-| **Last Commit** | Milestone 9c complete (heartbeat eviction + tests) |
+| **Current Branch** | `master` |
+| **Last Commit** | Sprint 9 complete (peer discovery merged, PR #72) |
 | **Tag** | `v1.0.0` (Phase 1) |
 | **Main Branch** | `master` |
 
@@ -176,16 +180,17 @@ _None currently._
 
 ## 📝 Notes for Next Session
 
-1. **Sprint 9 IN PROGRESS** - Node Discovery
-   - Milestones 9a, 9b, 9c complete
-   - 1 milestone remaining: 9d (Peer Discovery)
+1. **Sprint 9 COMPLETE** - Node Discovery
+   - All milestones 9a, 9b, 9c, 9d merged to master
+   - Peer discovery (GET_PEERS/PEERS gossip), seed bootstrap, heartbeat eviction live
 
-2. **Next: Milestone 9d** - Peer Discovery
-   - GetPeersMessage and PeersMessage classes
-   - GET_PEERS and PEERS handlers in Node
-   - Seed nodes config + bootstrap on startup
-   - Unit tests for peer discovery
+2. **Next: Sprint 10** - Block & Transaction Broadcasting
+   - Gossip new blocks and transactions across the peer network
+
+3. **Deferred / future work**
+   - Gossip auto-connect to DISCOVERED peers (needs MAX_PEERS guarding)
+   - Self-identification filtering in peer lists
 
 ---
 
-*Last updated: 2026-06-30 | Milestone 9c Complete*
+*Last updated: 2026-06-30 | Sprint 9 Complete (Milestone 9d)*

--- a/.ai/sprints/sprint9/sprint-log.md
+++ b/.ai/sprints/sprint9/sprint-log.md
@@ -5,7 +5,7 @@
 | Event | Date |
 |-------|------|
 | **Sprint Start** | 2026-02-09 |
-| **Sprint End** | TBD |
+| **Sprint End** | 2026-06-30 |
 
 ---
 
@@ -66,7 +66,35 @@
 
 ---
 
-## Milestone 9d: Peer Discovery - Pending
+## Milestone 9d: Peer Discovery - ✅ Complete (2026-06-30)
+
+### Delivered
+- `GetPeersMessage.java` / `PeersMessage.java` - peer discovery request/response messages ("host:port" list)
+- MessageParser registers GET_PEERS and PEERS in TYPE_REGISTRY
+- GET_PEERS handler - replies with known peer addresses
+- PEERS handler - records received addresses as DISCOVERED (record-only; auto-connect deferred), skips malformed entries
+- `Node.parseAddress(String)` helper - parses "host:port", NumberFormat-safe
+- `SEED_NODES` constant in NetworkConfig + `Node.bootstrap()` - connects to seed nodes on startup (skips self for local testing)
+- `PeerDiscoveryTest.java` - 5 unit tests (serialization round-trips, GET_PEERS reply, PEERS recording, malformed-address skipping)
+
+### Issues Closed
+- #68: Create GetPeersMessage and PeersMessage ✅
+- #69: Implement GET_PEERS and PEERS handlers ✅
+- #70: Add seed nodes config + bootstrap on startup ✅
+- #71: Unit tests for peer discovery ✅
+
+### Stats
+- Tests added: 5 (total: 137)
+- PR: #72 merged to master
+
+---
+
+## Sprint 9 Summary
+
+Sprint 9 (Node Discovery) complete. Delivered peer metadata tracking (PeerInfo/PeerState),
+a PeerManager registry with MAX_PEERS enforcement, heartbeat PING/PONG with dead-peer
+eviction, and peer discovery via GET_PEERS/PEERS gossip plus seed-node bootstrap.
+Tests grew from 114 → 137. Next: Sprint 10 (Block & Transaction Broadcasting).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ BlockSmith is a comprehensive blockchain project that goes beyond tutorials - im
 
 [![Java](https://img.shields.io/badge/Java-20+-orange.svg)](https://openjdk.org/)
 [![Maven](https://img.shields.io/badge/Maven-3.9+-blue.svg)](https://maven.apache.org/)
-[![Tests](https://img.shields.io/badge/Tests-120%20passing-brightgreen.svg)](#)
+[![Tests](https://img.shields.io/badge/Tests-137%20passing-brightgreen.svg)](#)
 [![Phase](https://img.shields.io/badge/Phase%202-In%20Progress-yellow.svg)](#)
 [![Version](https://img.shields.io/badge/Version-1.0.0-blue.svg)](#)
 
@@ -34,7 +34,11 @@ BlockSmith is a comprehensive blockchain project that goes beyond tutorials - im
 - ✅ Server-side TCP socket node (Sprint 8b)
 - ✅ Client-side peer connections with handshake (Sprint 8c)
 - ✅ Bidirectional message exchange with handler pattern (Sprint 8d)
-- 🔄 Node discovery and peer management (Sprint 9 - in progress)
+- ✅ Node discovery and peer management (Sprint 9)
+  - ✅ PeerInfo / PeerState metadata tracking (Sprint 9a)
+  - ✅ PeerManager registry with MAX_PEERS enforcement (Sprint 9b)
+  - ✅ Heartbeat PING/PONG with dead-peer eviction (Sprint 9c)
+  - ✅ Peer discovery (GET_PEERS/PEERS) + seed-node bootstrap (Sprint 9d)
 - 🔜 Block and transaction broadcasting (Sprint 10)
 - 🔜 Mempool synchronization (Sprint 11)
 
@@ -185,7 +189,7 @@ Average attempts: ~16^difficulty (~65,536 for difficulty 4)
 mvn clean compile
 ```
 
-### Run all tests (120 tests)
+### Run all tests (137 tests)
 ```bash
 mvn test
 ```
@@ -234,13 +238,14 @@ BlockSmith/
 │   │   ├── MessageContext.java # Connection wrapper
 │   │   ├── MessageListener.java # Async listener interface
 │   │   ├── NetworkConfig.java  # Network constants
-│   │   ├── Node.java           # Server node with message loop
+│   │   ├── Node.java           # Server node + message loop + heartbeat + discovery
 │   │   ├── Peer.java           # Client peer with async listener
 │   │   ├── PeerState.java     # Peer connection lifecycle
 │   │   ├── PeerInfo.java      # Peer metadata tracking
-│   │   └── messages/           # Concrete message classes
+│   │   ├── PeerManager.java   # Peer registry with MAX_PEERS enforcement
+│   │   └── messages/           # Concrete message classes (incl. GetPeers/Peers)
 │   └── BlockSmithDemo.java     # Main demo application
-├── src/test/java/              # 120 unit tests
+├── src/test/java/              # 137 unit tests
 ├── data/                       # Blockchain persistence (JSON)
 ├── pom.xml                     # Maven configuration
 └── README.md
@@ -263,7 +268,10 @@ BlockSmith/
 | PeerTest | 7 | Peer connections, handshake |
 | CommunicationTest | 6 | Bidirectional message exchange |
 | PeerInfoTest | 6 | Peer metadata and state transitions |
-| **Total** | **120** | All passing ✅ |
+| PeerManagerTest | 8 | Peer registry, MAX_PEERS enforcement |
+| HeartbeatTest | 4 | Heartbeat ping, dead-peer eviction |
+| PeerDiscoveryTest | 5 | Peer discovery messages and handlers |
+| **Total** | **137** | All passing ✅ |
 
 ---
 
@@ -308,7 +316,7 @@ BlockSmith/
 | Sprint | Title | Status |
 |--------|-------|--------|
 | Sprint 8 | P2P Networking | ✅ Complete (8a, 8b, 8c, 8d) |
-| Sprint 9 | Node Discovery | 🔄 In Progress (9a ✅) |
+| Sprint 9 | Node Discovery | ✅ Complete (9a, 9b, 9c, 9d) |
 | Sprint 10 | Block Broadcasting | ⬜ Planned |
 | Sprint 11 | Mempool Sync | ⬜ Planned |
 
@@ -344,4 +352,4 @@ This project is for educational purposes.
 
 ---
 
-*Last updated: 2026-02-10 | Phase 2 Sprint 9 Milestone 9a Complete*
+*Last updated: 2026-06-30 | Phase 2 Sprint 9 Complete (Node Discovery)*


### PR DESCRIPTION
## Summary
- Update STATUS.md, sprint-log.md, and README.md to reflect Sprint 9 (Node Discovery) fully complete (milestones 9a-9d merged).
- Test count updated 120 -> 137; add PeerManagerTest (8), HeartbeatTest (4), and PeerDiscoveryTest (5) to coverage tables.
- Document peer-discovery features (GET_PEERS/PEERS gossip, seed-node bootstrap) and set next target to Sprint 10 (Broadcasting).

## Test plan
- [x] Docs-only change; no code touched.
- [x] `mvn test` already green at 137 tests on master after PR #72.