### PR TITLE
Sprint 10a: blockchain integration + external block append

### DIFF
--- a/src/main/java/com/blocksmith/core/Blockchain.java
+++ b/src/main/java/com/blocksmith/core/Blockchain.java
@@ -83,8 +83,51 @@ public class Blockchain {
         newBlock.mineBlock(BlockchainConfig.MINING_DIFFICULTY);
 
         chain.add(newBlock);
-        
+
         return newBlock;
+    }
+
+    /**
+     * Appends a block mined elsewhere (e.g. received from a peer) after
+     * validating it against the current chain tip.
+     *
+     * THEORY: ACCEPTING EXTERNAL BLOCKS
+     *
+     * Unlike addBlock(String), which mines a block locally, this method
+     * takes an already-mined block and accepts it only if it extends our
+     * chain cleanly. The block arrives from the untrusted network, so we
+     * re-verify everything rather than trust the sender:
+     *   1. Index is exactly tip + 1 (no gaps, no duplicates)
+     *   2. previousHash links to our current tip
+     *   3. The stored hash matches a fresh recomputation (integrity)
+     *   4. The hash satisfies the Proof-of-Work target (it was really mined)
+     *
+     * Returns false instead of throwing: a bad block is a normal network
+     * event, not a programming error.
+     *
+     * @param block A block mined elsewhere
+     * @return true if the block was valid and appended, false otherwise
+     */
+    public boolean addBlock(Block block) {
+        if (block == null) return false;
+
+        Block tip = getLatestBlock();
+
+        // 1. Must be the next index in the chain
+        if (block.getIndex() != tip.getIndex() + 1) return false;
+
+        // 2. Must link to our current tip
+        if (!block.getPreviousHash().equals(tip.getHash())) return false;
+
+        // 3. Stored hash must match a fresh recomputation
+        if (!block.getHash().equals(block.calculateHash())) return false;
+
+        // 4. Hash must meet the Proof-of-Work target
+        String target = "0".repeat(BlockchainConfig.MINING_DIFFICULTY);
+        if (!block.getHash().startsWith(target)) return false;
+
+        chain.add(block);
+        return true;
     }
 
     /**

--- a/src/main/java/com/blocksmith/network/Node.java
+++ b/src/main/java/com/blocksmith/network/Node.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 
+import com.blocksmith.core.Blockchain;
 import com.blocksmith.network.messages.PongMessage;
 import com.blocksmith.network.messages.HelloMessage;
 import com.blocksmith.network.messages.PingMessage;
@@ -57,6 +58,7 @@ public class Node {
     private Thread acceptThread;
     private final Map<MessageType, MessageHandler> handlers;
     private final PeerManager peerManager;
+    private final Blockchain blockchain;
     private final List<Peer> outboundPeers;
     private final Map<String, PrintWriter> peerWriters = new ConcurrentHashMap<>();
     private ScheduledExecutorService heartbeatScheduler;
@@ -69,13 +71,24 @@ public class Node {
     }
 
     /**
-     * Creates a new Node on specified port.
-     * 
+     * Creates a new Node on the specified port with a fresh Blockchain.
+     *
      * @param port The port to listen on
      */
     public Node(int port) {
+        this(port, new Blockchain());
+    }
+
+    /**
+     * Creates a new Node on the specified port backed by the given Blockchain.
+     *
+     * @param port The port to listen on
+     * @param blockchain The blockchain this node validates and extends
+     */
+    public Node(int port, Blockchain blockchain) {
         this.nodeId = generateNodeId();
         this.port = port;
+        this.blockchain = blockchain;
         this.running = false;
         this.handlers = new HashMap<>();
         this.peerManager = new PeerManager();
@@ -366,7 +379,7 @@ public class Node {
                 nodeId,
                 NetworkConfig.PROTOCOL_VERSION,
                 port,
-                0  // chainLength - will be set when blockchain is integrated
+                blockchain.getChainSize()
             );
             writer.println(response.toJson());
             System.out.println("  → Sent HELLO response to " + peerHello.getNodeId());
@@ -459,7 +472,7 @@ public class Node {
         // Create and connect
         Peer peer = new Peer(host, port);
         peer.connect();
-        peer.performHandshake(nodeId, this.port, 0);
+        peer.performHandshake(nodeId, this.port, blockchain.getChainSize());
 
         // Register in PeerManager
         PeerInfo peerInfo = new PeerInfo(host, port);
@@ -572,6 +585,10 @@ public class Node {
 
     public PeerManager getPeerManager() {
         return peerManager;
+    }
+
+    public Blockchain getBlockchain() {
+        return blockchain;
     }
 
     public boolean isRunning() {

--- a/src/test/java/com/blocksmith/core/ExternalBlockTest.java
+++ b/src/test/java/com/blocksmith/core/ExternalBlockTest.java
@@ -1,0 +1,82 @@
+package com.blocksmith.core;
+
+import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.blocksmith.util.BlockchainConfig;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for Blockchain.addBlock(Block) - accepting an externally-mined
+ * block (e.g. one received from a peer) after validation.
+ */
+@DisplayName("External Block Append Tests")
+class ExternalBlockTest {
+
+    private Blockchain blockchain;
+
+    @BeforeEach
+    void setUp() {
+        blockchain = new Blockchain();
+    }
+
+    /** Builds a valid, mined block that extends the current chain tip. */
+    private Block mineNextBlock() {
+        Block tip = blockchain.getLatestBlock();
+        Block next = new Block(tip.getIndex() + 1, "external", tip.getHash());
+        next.mineBlock(BlockchainConfig.MINING_DIFFICULTY);
+        return next;
+    }
+
+    @Test
+    @DisplayName("Valid externally-mined block is appended")
+    void addBlock_appendsValidExternalBlock() {
+        Block next = mineNextBlock();
+
+        assertTrue(blockchain.addBlock(next), "Valid block should be accepted");
+        assertEquals(2, blockchain.getChainSize(), "Chain should grow by one");
+        assertSame(next, blockchain.getLatestBlock(), "Appended block becomes the new tip");
+    }
+
+    @Test
+    @DisplayName("Block with a non-sequential index is rejected")
+    void addBlock_rejectsWrongIndex() {
+        Block tip = blockchain.getLatestBlock();
+        Block gap = new Block(tip.getIndex() + 2, "external", tip.getHash());
+        gap.mineBlock(BlockchainConfig.MINING_DIFFICULTY);
+
+        assertFalse(blockchain.addBlock(gap), "Wrong index should be rejected");
+        assertEquals(1, blockchain.getChainSize(), "Chain must be unchanged");
+    }
+
+    @Test
+    @DisplayName("Block whose previousHash does not match the tip is rejected")
+    void addBlock_rejectsWrongPreviousHash() {
+        Block tip = blockchain.getLatestBlock();
+        Block wrongLink = new Block(tip.getIndex() + 1, "external", "deadbeef");
+        wrongLink.mineBlock(BlockchainConfig.MINING_DIFFICULTY);
+
+        assertFalse(blockchain.addBlock(wrongLink), "Broken link should be rejected");
+        assertEquals(1, blockchain.getChainSize(), "Chain must be unchanged");
+    }
+
+    @Test
+    @DisplayName("Block whose stored hash does not match its contents is rejected")
+    void addBlock_rejectsTamperedHash() throws Exception {
+        Block next = mineNextBlock();
+
+        // Corrupt the stored hash: still starts with the PoW target so it
+        // passes the difficulty check, but no longer matches calculateHash().
+        String target = "0".repeat(BlockchainConfig.MINING_DIFFICULTY);
+        Field hashField = Block.class.getDeclaredField("hash");
+        hashField.setAccessible(true);
+        hashField.set(next, target + "f".repeat(64 - target.length()));
+
+        assertFalse(blockchain.addBlock(next), "Tampered block should be rejected");
+        assertEquals(1, blockchain.getChainSize(), "Chain must be unchanged");
+    }
+}

--- a/src/test/java/com/blocksmith/network/ChainIntegrationTest.java
+++ b/src/test/java/com/blocksmith/network/ChainIntegrationTest.java
@@ -1,0 +1,74 @@
+package com.blocksmith.network;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.net.Socket;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.blocksmith.core.Blockchain;
+import com.blocksmith.network.messages.HelloMessage;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests that Node is backed by a Blockchain and reports its real chain
+ * length during the HELLO handshake (Milestone 10a).
+ */
+@DisplayName("Chain Integration Tests")
+class ChainIntegrationTest {
+
+    private Node node;
+
+    private static final int TEST_PORT_BASE = 19700;
+    private static int portCounter = 0;
+
+    private int getNextPort() {
+        return TEST_PORT_BASE + (portCounter++);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (node != null) {
+            node.stop();
+        }
+    }
+
+    @Test
+    @DisplayName("Node exposes the injected blockchain")
+    void node_exposesBlockchain() {
+        Blockchain chain = new Blockchain();
+        node = new Node(getNextPort(), chain);
+
+        assertSame(chain, node.getBlockchain(), "getBlockchain() returns the injected chain");
+    }
+
+    @Test
+    @DisplayName("HELLO response carries the node's real chain length")
+    void node_helloCarriesChainLength() throws Exception {
+        Blockchain chain = new Blockchain();
+        chain.addBlock("block-1");
+        chain.addBlock("block-2");
+        int expected = chain.getChainSize(); // genesis + 2 = 3
+
+        int port = getNextPort();
+        node = new Node(port, chain);
+        node.start();
+
+        try (Socket socket = new Socket("localhost", port)) {
+            PrintWriter out = new PrintWriter(socket.getOutputStream(), true);
+            BufferedReader in = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+
+            out.println(new HelloMessage("client", NetworkConfig.PROTOCOL_VERSION, 12345, 1).toJson());
+
+            String responseJson = in.readLine();
+            HelloMessage response = Message.fromJson(responseJson, HelloMessage.class);
+
+            assertEquals(expected, response.getChainLength(),
+                    "HELLO response should report the real chain length");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `Blockchain.addBlock(Block)` to validate and append an externally-mined block (index, previousHash link, hash integrity, PoW target); returns false for invalid blocks rather than throwing.
- Wire a `Blockchain` into `Node` (injectable constructor, fresh by default) with a `getBlockchain()` getter.
- HELLO handshakes now report the real chain length instead of the hard-coded `0` placeholder (Node.java:369).

## Why
Foundation for Sprint 10 block broadcasting: a node must be able to validate and store a block received from a peer before NEW_BLOCK relay (10b), orphan handling (10c), and chain sync (10d) make sense.

## Tests
- `ExternalBlockTest` (4): valid append, wrong index, broken prevHash link, tampered hash.
- `ChainIntegrationTest` (2): node exposes its blockchain; HELLO carries real chain length (verified over a raw loopback socket).
- Full suite: 143 passing (was 137).

Closes #74
Closes #75
Closes #76