### PR TITLE
Sprint 10c: orphan block handling

### DIFF
--- a/src/main/java/com/blocksmith/core/Blockchain.java
+++ b/src/main/java/com/blocksmith/core/Blockchain.java
@@ -4,7 +4,9 @@ import com.blocksmith.util.BlockchainConfig;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Manages the blockchain - a linked list of blocks.
@@ -35,6 +37,31 @@ public class Blockchain {
 
     private final List<Block> chain;
     private final List<Transaction> pendingTransactions;
+
+    /**
+     * Largest number of orphan blocks held at once. Caps memory if a peer
+     * floods us with forward blocks whose parents never arrive.
+     */
+    static final int MAX_ORPHANS = 50;
+
+    /**
+     * THEORY: ORPHAN BLOCKS
+     *
+     * Over a gossip network a block can arrive before its parent. Such a
+     * block is an "orphan" - valid in isolation but not yet connectable to
+     * our chain. We park it here, keyed by the previousHash it is waiting
+     * for, and attach it once that parent block is appended.
+     *
+     * A LinkedHashMap in access-order eviction mode drops the oldest orphan
+     * when the buffer is full, bounding memory.
+     */
+    private final Map<String, Block> orphans =
+            new LinkedHashMap<>(16, 0.75f, false) {
+                @Override
+                protected boolean removeEldestEntry(Map.Entry<String, Block> eldest) {
+                    return size() > MAX_ORPHANS;
+                }
+            };
 
     /**
      * Creates a new blockchain with the Genesis block.
@@ -111,23 +138,66 @@ public class Blockchain {
     public boolean addBlock(Block block) {
         if (block == null) return false;
 
+        // A block must be internally sound (hash integrity + PoW) before we
+        // either append or buffer it. A malformed block is dropped outright.
+        if (!isWellFormed(block)) return false;
+
         Block tip = getLatestBlock();
 
-        // 1. Must be the next index in the chain
-        if (block.getIndex() != tip.getIndex() + 1) return false;
+        // Extends our current tip cleanly: append, then pull in any orphans
+        // that were waiting on this new block.
+        if (block.getIndex() == tip.getIndex() + 1
+                && block.getPreviousHash().equals(tip.getHash())) {
+            chain.add(block);
+            attachOrphans();
+            return true;
+        }
 
-        // 2. Must link to our current tip
-        if (!block.getPreviousHash().equals(tip.getHash())) return false;
+        // Arrived ahead of its parent (index beyond tip+1): park as an orphan
+        // until the missing parent shows up.
+        if (block.getIndex() > tip.getIndex() + 1) {
+            orphans.put(block.getPreviousHash(), block);
+        }
 
-        // 3. Stored hash must match a fresh recomputation
+        return false;
+    }
+
+    /**
+     * Checks a block is internally consistent: its stored hash matches a
+     * fresh recomputation and satisfies the Proof-of-Work target. Says
+     * nothing about how it links to our chain.
+     */
+    private boolean isWellFormed(Block block) {
         if (!block.getHash().equals(block.calculateHash())) return false;
-
-        // 4. Hash must meet the Proof-of-Work target
         String target = "0".repeat(BlockchainConfig.MINING_DIFFICULTY);
-        if (!block.getHash().startsWith(target)) return false;
+        return block.getHash().startsWith(target);
+    }
 
-        chain.add(block);
-        return true;
+    /**
+     * Drains the orphan buffer onto the chain: while an orphan is waiting on
+     * the current tip's hash, append it and advance. A run of consecutive
+     * out-of-order blocks resolves in a single pass.
+     */
+    private void attachOrphans() {
+        while (true) {
+            Block tip = getLatestBlock();
+            Block child = orphans.get(tip.getHash());
+            if (child == null) break;
+
+            orphans.remove(tip.getHash());
+            if (child.getIndex() == tip.getIndex() + 1 && isWellFormed(child)) {
+                chain.add(child);
+            } else {
+                break; // stale/ill-fitting orphan: drop and stop
+            }
+        }
+    }
+
+    /**
+     * @return number of blocks currently held in the orphan buffer
+     */
+    public int getOrphanCount() {
+        return orphans.size();
     }
 
     /**

--- a/src/test/java/com/blocksmith/core/OrphanBlockTest.java
+++ b/src/test/java/com/blocksmith/core/OrphanBlockTest.java
@@ -1,0 +1,74 @@
+package com.blocksmith.core;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.blocksmith.util.BlockchainConfig;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for orphan block handling in Blockchain - buffering blocks that
+ * arrive before their parent and attaching them once the parent appears.
+ */
+@DisplayName("Orphan Block Tests")
+class OrphanBlockTest {
+
+    private Blockchain blockchain;
+
+    @BeforeEach
+    void setUp() {
+        blockchain = new Blockchain();
+    }
+
+    /** Mines a well-formed block at the given index linking to parentHash. */
+    private Block mine(int index, String parentHash) {
+        Block block = new Block(index, "orphan", parentHash);
+        block.mineBlock(BlockchainConfig.MINING_DIFFICULTY);
+        return block;
+    }
+
+    @Test
+    @DisplayName("Out-of-order blocks are buffered then attached when the parent arrives")
+    void outOfOrderBlocks_bufferThenAttach() {
+        Block genesis = blockchain.getLatestBlock();
+        Block n = mine(1, genesis.getHash());
+        Block n1 = mine(2, n.getHash());
+
+        // Child arrives first: cannot connect yet, so it is buffered.
+        assertFalse(blockchain.addBlock(n1), "Child has no parent yet -> not appended");
+        assertEquals(1, blockchain.getChainSize(), "Chain unchanged while child is orphaned");
+        assertEquals(1, blockchain.getOrphanCount(), "Child should be buffered");
+
+        // Parent arrives: it appends and pulls the buffered child in behind it.
+        assertTrue(blockchain.addBlock(n), "Parent extends the tip -> appended");
+        assertEquals(3, blockchain.getChainSize(), "Parent and child both end up in the chain");
+        assertEquals(0, blockchain.getOrphanCount(), "Buffer drained after attaching");
+        assertEquals(n1.getHash(), blockchain.getLatestBlock().getHash(),
+                "Child should be the new tip");
+    }
+
+    @Test
+    @DisplayName("Orphan buffer is bounded")
+    void orphanBuffer_isBounded() {
+        for (int i = 0; i < Blockchain.MAX_ORPHANS + 10; i++) {
+            // Distinct parent hashes -> distinct buffer keys; index beyond tip+1.
+            blockchain.addBlock(mine(2 + i, "parent-" + i));
+        }
+
+        assertEquals(Blockchain.MAX_ORPHANS, blockchain.getOrphanCount(),
+                "Buffer must not grow past its cap");
+        assertEquals(1, blockchain.getChainSize(), "No orphan should have attached");
+    }
+
+    @Test
+    @DisplayName("Orphan whose parent never arrives stays buffered")
+    void orphanWithNoParent_staysBuffered() {
+        Block orphan = mine(5, "ghost-parent");
+
+        assertFalse(blockchain.addBlock(orphan), "Disconnected block is not appended");
+        assertEquals(1, blockchain.getChainSize(), "Chain remains just the genesis block");
+        assertEquals(1, blockchain.getOrphanCount(), "Orphan remains buffered");
+    }
+}


### PR DESCRIPTION
## Summary
- Add a bounded orphan buffer to `Blockchain`: a block arriving ahead of its parent (index beyond tip+1) is parked, keyed by the previousHash it awaits, instead of being dropped.
- After any successful append, `attachOrphans()` drains the buffer onto the new tip, so a run of out-of-order blocks resolves in a single pass.
- `addBlock(Block)` now separates internal soundness (hash integrity + PoW) from chain linkage, cleanly deciding between append, buffer, and reject.
- Buffer is capped at `MAX_ORPHANS` (50) via a LinkedHashMap that evicts the oldest entry.

## Tests
- `OrphanBlockTest` (3): out-of-order buffer-then-attach, buffer boundedness, disconnected orphan stays buffered.
- Full suite: 150 passing (was 147).

## Notes
- A buffered orphan that later attaches is not itself re-gossiped (only the parent's append triggers relay). Acceptable for now; full fork/relay completeness belongs with chain sync (10d).

Closes #83
Closes #84
Closes #85