### PR TITLE
docs: Sprint 10 complete (Block Broadcasting)

### DIFF
--- a/.ai/STATUS.md
+++ b/.ai/STATUS.md
@@ -9,9 +9,9 @@
 | Field | Value |
 |-------|-------|
 | **Phase** | 2 - Network Layer |
-| **Current Sprint** | 9 (Node Discovery) - Complete |
-| **Current Milestone** | 9d Complete (Peer Discovery) |
-| **Status** | Sprint 9 complete (9a-9d), next: Sprint 10 (Broadcasting) |
+| **Current Sprint** | 10 (Block Broadcasting) - Complete |
+| **Current Milestone** | 10d Complete (Chain Sync) |
+| **Status** | Sprint 10 complete (10a-10d), next: Sprint 11 (Mempool Sync) |
 
 ---
 
@@ -40,11 +40,11 @@ Phase 1: Core Blockchain     [███████████████] 100
 ├── Sprint 5: Wallets        ✅
 └── Sprint 6: Economics      ✅
 
-Phase 2: Network Layer       [████████░░░░░░░] 50% ← CURRENT
+Phase 2: Network Layer       [███████████░░░░] 75% ← CURRENT
 ├── Sprint 8: P2P Networking ✅ COMPLETE (8a ✅, 8b ✅, 8c ✅, 8d ✅)
 ├── Sprint 9: Node Discovery ✅ COMPLETE (9a ✅, 9b ✅, 9c ✅, 9d ✅)
-├── Sprint 10: Broadcasting  ⬜ ← NEXT
-└── Sprint 11: Mempool Sync  ⬜
+├── Sprint 10: Broadcasting  ✅ COMPLETE (10a ✅, 10b ✅, 10c ✅, 10d ✅)
+└── Sprint 11: Mempool Sync  ⬜ ← NEXT
 ```
 
 ---
@@ -67,7 +67,12 @@ Phase 2: Network Layer       [████████░░░░░░░] 50%
 | PeerManagerTest | 8 | ✅ |
 | HeartbeatTest | 4 | ✅ |
 | PeerDiscoveryTest | 5 | ✅ |
-| **Total** | **137** | ✅ |
+| ChainIntegrationTest | 2 | ✅ |
+| ExternalBlockTest | 4 | ✅ |
+| BlockBroadcastTest | 4 | ✅ |
+| OrphanBlockTest | 3 | ✅ |
+| ChainSyncTest | 5 | ✅ |
+| **Total** | **155** | ✅ |
 
 Last test run: `mvn test` - All passing
 
@@ -80,7 +85,7 @@ Last test run: `mvn test` - All passing
 | Class | Status | Lines | Notes |
 |-------|--------|-------|-------|
 | Block.java | ✅ Complete | ~268 | Transactions + Merkle root |
-| Blockchain.java | ✅ Complete | ~338 | Pending pool + mining |
+| Blockchain.java | ✅ Complete | ~470 | Pending pool + mining + external append + orphan buffer (Sprint 10) |
 | Transaction.java | ✅ Complete | ~200 | Validation + signing + verification |
 | Wallet.java | ✅ Complete | ~169 | ECDSA keys + signing |
 
@@ -99,7 +104,7 @@ Last test run: `mvn test` - All passing
 | MessageType.java | ✅ Complete | ~45 | Message types enum |
 | Message.java | ✅ Complete | ~82 | Base message class |
 | NetworkConfig.java | ✅ Complete | ~103 | Network constants + heartbeat + seed nodes |
-| Node.java | ✅ Complete | ~560 | Server + message loop + peer tracking + heartbeat eviction + peer discovery + seed bootstrap |
+| Node.java | ✅ Complete | ~595 | Server + message loop + peer tracking + heartbeat eviction + peer discovery + seed bootstrap + block broadcast + chain sync (Sprint 10) |
 | Peer.java | ✅ Complete | ~294 | Client + async listener thread |
 | MessageParser.java | ✅ Complete | ~116 | JSON-to-Message routing (Sprint 8d) |
 | MessageHandler.java | ✅ Complete | ~36 | Handler functional interface (Sprint 8d) |
@@ -108,7 +113,7 @@ Last test run: `mvn test` - All passing
 | PeerState.java | ✅ Complete | ~43 | Peer connection lifecycle enum (Sprint 9a) |
 | PeerInfo.java | ✅ Complete | ~110 | Peer metadata tracking (Sprint 9a) |
 | PeerManager.java | ✅ Complete | ~145 | Peer registry, MAX_PEERS enforcement (Sprint 9b) |
-| messages/*.java | ✅ Complete | ~180 | 7 concrete message types (+ GetPeers/Peers, Sprint 9d) |
+| messages/*.java | ✅ Complete | ~230 | 9 concrete message types (+ GetBlocks/Blocks, Sprint 10d) |
 
 ### Demo
 
@@ -158,6 +163,13 @@ Last test run: `mvn test` - All passing
 - [x] GetPeersMessage / PeersMessage for peer discovery gossip (Sprint 9d)
 - [x] GET_PEERS / PEERS handlers in Node (Sprint 9d)
 - [x] Seed-node config + bootstrap on startup (Sprint 9d)
+- [x] Blockchain reference wired into Node + real HELLO chain length (Sprint 10a)
+- [x] External block append with validation, no re-mining (Sprint 10a)
+- [x] Node.broadcastBlock + NEW_BLOCK validate/append/re-gossip (Sprint 10b)
+- [x] Sender exclusion on relay to prevent gossip storms (Sprint 10b)
+- [x] Bounded orphan buffer with attach-on-parent-arrival (Sprint 10c)
+- [x] GetBlocksMessage / BlocksMessage for chain sync (Sprint 10d)
+- [x] GET_BLOCKS / BLOCKS handlers + behind-peer sync trigger (Sprint 10d)
 
 ---
 
@@ -166,7 +178,7 @@ Last test run: `mvn test` - All passing
 | Item | Value |
 |------|-------|
 | **Current Branch** | `master` |
-| **Last Commit** | Sprint 9 complete (peer discovery merged, PR #72) |
+| **Last Commit** | Sprint 10 complete (chain sync merged, PR #91) |
 | **Tag** | `v1.0.0` (Phase 1) |
 | **Main Branch** | `master` |
 
@@ -180,17 +192,20 @@ _None currently._
 
 ## 📝 Notes for Next Session
 
-1. **Sprint 9 COMPLETE** - Node Discovery
-   - All milestones 9a, 9b, 9c, 9d merged to master
-   - Peer discovery (GET_PEERS/PEERS gossip), seed bootstrap, heartbeat eviction live
+1. **Sprint 10 COMPLETE** - Block Broadcasting
+   - All milestones 10a, 10b, 10c, 10d merged to master
+   - Block gossip (NEW_BLOCK), orphan buffering, and chain sync (GET_BLOCKS/BLOCKS) live
+   - Node now carries a real Blockchain; HELLO reports the true chain length
 
-2. **Next: Sprint 10** - Block & Transaction Broadcasting
-   - Gossip new blocks and transactions across the peer network
+2. **Next: Sprint 11** - Mempool Sync
+   - Gossip pending transactions across the peer network
 
 3. **Deferred / future work**
+   - Deterministic genesis block (current genesis uses a wall-clock timestamp,
+     so independent nodes cannot sync in a real multi-node demo)
    - Gossip auto-connect to DISCOVERED peers (needs MAX_PEERS guarding)
    - Self-identification filtering in peer lists
 
 ---
 
-*Last updated: 2026-06-30 | Sprint 9 Complete (Milestone 9d)*
+*Last updated: 2026-06-30 | Sprint 10 Complete (Milestone 10d)*

--- a/.ai/sprints/sprint10/sprint-log.md
+++ b/.ai/sprints/sprint10/sprint-log.md
@@ -5,34 +5,74 @@
 | Event | Date |
 |-------|------|
 | **Sprint Start** | 2026-06-30 |
-| **Sprint End** | TBD |
+| **Sprint End** | 2026-06-30 |
 
 ---
 
-## Milestone 10a: Blockchain integration + external block append - Pending
+## Milestone 10a: Blockchain integration + external block append - Complete
+
+- Wired a `Blockchain` reference into `Node` (constructor injection + `getBlockchain()`)
+- HELLO handshake now reports the real chain length (replaced the `0` placeholder)
+- Added `Blockchain.addBlock(Block)` to append externally-mined blocks after
+  validating index, previousHash, hash integrity, and PoW (no re-mining)
+- Issues #74, #75, #76 - merged via PR #78
+- Tests: `ExternalBlockTest` (4), `ChainIntegrationTest` (2)
 
 ---
 
-## Milestone 10b: Block broadcast (NEW_BLOCK) - Pending
+## Milestone 10b: Block broadcast (NEW_BLOCK) - Complete
+
+- Added `Node.broadcastBlock(Block)` / `broadcastBlock(Block, excludeNodeId)`
+- NEW_BLOCK handler validates, appends, and re-gossips a newly accepted block;
+  duplicates and invalid blocks fail `addBlock` so they are not relayed (no storm)
+- Sender exclusion on relay to avoid bouncing a block back to its source
+- Issues #77, #78, #79 - merged via PR #82
+- Tests: `BlockBroadcastTest` (4)
 
 ---
 
-## Milestone 10c: Orphan block handling - Pending
+## Milestone 10c: Orphan block handling - Complete
+
+- Bounded orphan buffer (`MAX_ORPHANS = 50`) keyed by previousHash
+- Blocks arriving ahead of their parent are buffered, then attached once the
+  parent appears; chains of orphans resolve in a single pass
+- Issues #80, #81, #82 - merged via PR #86
+- Tests: `OrphanBlockTest` (3)
 
 ---
 
-## Milestone 10d: Chain sync (request missing blocks) - Pending
+## Milestone 10d: Chain sync (request missing blocks) - Complete
+
+- Added `GetBlocksMessage(nodeId, fromIndex)` and `BlocksMessage(nodeId, blocks)`,
+  registered in `MessageParser`
+- GET_BLOCKS handler serves blocks from the requested index to the tip;
+  BLOCKS handler applies the received range in order via `addBlock`
+- NEW_BLOCK handler detects an ahead-peer (block beyond tip+1) and requests the
+  gap with `GetBlocksMessage(fromIndex = getChainSize())`
+- Issues #87, #88, #89, #90 - merged via PR #91
+- Tests: `ChainSyncTest` (5)
+
+---
+
+## Outcome
+
+- **Sprint 10 complete** (10a-10d): blocks now propagate across the peer network,
+  out-of-order delivery is tolerated, and a behind node can catch up via sync
+- Test count: 137 -> 155 (+18)
 
 ---
 
 ## Notes
 
-- Continuing issue-first, milestone-per-branch workflow from Sprints 8-9
+- Continued issue-first, milestone-per-branch workflow from Sprints 8-9
 - Last Sprint 9 issue: #71 (PRs went up to #73)
-- Sprint 10 issues start at #74
-- Foundational gap: Node had no Blockchain reference (placeholder at
-  Node.java:369) - 10a wires it in before any broadcasting
+- Sprint 10 issues started at #74 (PRs consumed some numbers, so the final 10d
+  issues landed at #87-90, merged by PR #91)
+- Foundational gap closed in 10a: Node previously had no Blockchain reference
+- Known follow-up: every `new Blockchain()` mines a genesis with a wall-clock
+  timestamp, so independent chains never share a genesis hash. A real multi-node
+  sync demo needs a deterministic (fixed/hardcoded) genesis
 
 ---
 
-*Created: 2026-06-30*
+*Created: 2026-06-30 | Completed: 2026-06-30*

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ BlockSmith is a comprehensive blockchain project that goes beyond tutorials - im
 
 [![Java](https://img.shields.io/badge/Java-20+-orange.svg)](https://openjdk.org/)
 [![Maven](https://img.shields.io/badge/Maven-3.9+-blue.svg)](https://maven.apache.org/)
-[![Tests](https://img.shields.io/badge/Tests-137%20passing-brightgreen.svg)](#)
+[![Tests](https://img.shields.io/badge/Tests-155%20passing-brightgreen.svg)](#)
 [![Phase](https://img.shields.io/badge/Phase%202-In%20Progress-yellow.svg)](#)
 [![Version](https://img.shields.io/badge/Version-1.0.0-blue.svg)](#)
 
@@ -29,7 +29,7 @@ BlockSmith is a comprehensive blockchain project that goes beyond tutorials - im
 - ✅ Balance validation before transfers
 - ✅ Double-spend prevention (pending tracking)
 
-### Phase 2: Network Layer 🔄 In Progress (50%)
+### Phase 2: Network Layer 🔄 In Progress (75%)
 - ✅ Message protocol with JSON serialization (Sprint 8a)
 - ✅ Server-side TCP socket node (Sprint 8b)
 - ✅ Client-side peer connections with handshake (Sprint 8c)
@@ -39,7 +39,11 @@ BlockSmith is a comprehensive blockchain project that goes beyond tutorials - im
   - ✅ PeerManager registry with MAX_PEERS enforcement (Sprint 9b)
   - ✅ Heartbeat PING/PONG with dead-peer eviction (Sprint 9c)
   - ✅ Peer discovery (GET_PEERS/PEERS) + seed-node bootstrap (Sprint 9d)
-- 🔜 Block and transaction broadcasting (Sprint 10)
+- ✅ Block broadcasting (Sprint 10)
+  - ✅ Blockchain wired into Node + external block append (Sprint 10a)
+  - ✅ NEW_BLOCK broadcast, validate, and re-gossip (Sprint 10b)
+  - ✅ Orphan block buffering and attachment (Sprint 10c)
+  - ✅ Chain sync (GET_BLOCKS/BLOCKS) for behind nodes (Sprint 10d)
 - 🔜 Mempool synchronization (Sprint 11)
 
 ### Phase 3: API & Interface 🔜 Planned
@@ -189,7 +193,7 @@ Average attempts: ~16^difficulty (~65,536 for difficulty 4)
 mvn clean compile
 ```
 
-### Run all tests (137 tests)
+### Run all tests (155 tests)
 ```bash
 mvn test
 ```
@@ -245,7 +249,7 @@ BlockSmith/
 │   │   ├── PeerManager.java   # Peer registry with MAX_PEERS enforcement
 │   │   └── messages/           # Concrete message classes (incl. GetPeers/Peers)
 │   └── BlockSmithDemo.java     # Main demo application
-├── src/test/java/              # 137 unit tests
+├── src/test/java/              # 155 unit tests
 ├── data/                       # Blockchain persistence (JSON)
 ├── pom.xml                     # Maven configuration
 └── README.md
@@ -271,7 +275,12 @@ BlockSmith/
 | PeerManagerTest | 8 | Peer registry, MAX_PEERS enforcement |
 | HeartbeatTest | 4 | Heartbeat ping, dead-peer eviction |
 | PeerDiscoveryTest | 5 | Peer discovery messages and handlers |
-| **Total** | **137** | All passing ✅ |
+| ChainIntegrationTest | 2 | Node-backed blockchain, HELLO chain length |
+| ExternalBlockTest | 4 | External block append + validation |
+| BlockBroadcastTest | 4 | NEW_BLOCK serialization and handler |
+| OrphanBlockTest | 3 | Orphan buffering and attachment |
+| ChainSyncTest | 5 | GET_BLOCKS/BLOCKS sync handlers |
+| **Total** | **155** | All passing ✅ |
 
 ---
 
@@ -312,12 +321,12 @@ BlockSmith/
 | Sprint 5 | Wallets & Digital Signatures | ✅ Complete |
 | Sprint 6 | Economic System | ✅ Complete |
 
-### Phase 2: Network Layer (50% Complete)
+### Phase 2: Network Layer (75% Complete)
 | Sprint | Title | Status |
 |--------|-------|--------|
 | Sprint 8 | P2P Networking | ✅ Complete (8a, 8b, 8c, 8d) |
 | Sprint 9 | Node Discovery | ✅ Complete (9a, 9b, 9c, 9d) |
-| Sprint 10 | Block Broadcasting | ⬜ Planned |
+| Sprint 10 | Block Broadcasting | ✅ Complete (10a, 10b, 10c, 10d) |
 | Sprint 11 | Mempool Sync | ⬜ Planned |
 
 ### Phase 3: API & Interface
@@ -352,4 +361,4 @@ This project is for educational purposes.
 
 ---
 
-*Last updated: 2026-06-30 | Phase 2 Sprint 9 Complete (Node Discovery)*
+*Last updated: 2026-06-30 | Phase 2 Sprint 10 Complete (Block Broadcasting)*


### PR DESCRIPTION
## Summary
Marks Sprint 10 (Block Broadcasting) complete across the project docs, following the Sprint 9 pattern.

- **STATUS.md**: sprint/milestone set to 10d complete, Phase 2 progress 50% -> 75%, test summary 137 -> 155 (5 new test classes), implementation notes and feature list updated, next-session notes point to Sprint 11.
- **README.md**: tests badge + counts 137 -> 155, Phase 2 feature list and roadmap show Sprint 10 complete, test-coverage table extended.
- **sprint10/sprint-log.md**: all four milestones (10a-10d) written up with their issues/PRs and tests; outcome and follow-ups recorded.

## Notes
- Recorded a known follow-up: genesis blocks embed a wall-clock timestamp, so independent nodes can't sync in a real multi-node demo until genesis is deterministic.

## Test plan
- [x] Docs-only change; `mvn test` already green at 155 from PR #91