### PR TITLE
fix: deterministic genesis block (fixed timestamp)

### DIFF
--- a/src/main/java/com/blocksmith/core/Block.java
+++ b/src/main/java/com/blocksmith/core/Block.java
@@ -64,8 +64,22 @@ public class Block {
      * @param previousHash Hash of the previous block
      */
     public Block(int index, String data, String previousHash) {
+        this(index, data, previousHash, System.currentTimeMillis());
+    }
+
+    /**
+     * Creates a data block with an explicit timestamp.
+     * Used for the Genesis block, whose timestamp must be fixed so its hash is
+     * identical on every node.
+     *
+     * @param index Block number in the chain
+     * @param data Block content (simple string)
+     * @param previousHash Hash of the previous block
+     * @param timestamp Creation time (Unix millis)
+     */
+    public Block(int index, String data, String previousHash, long timestamp) {
         this.index = index;
-        this.timestamp = System.currentTimeMillis();
+        this.timestamp = timestamp;
         this.data = data;
         this.transactions = new ArrayList<>();  // Empty list
         this.previousHash = previousHash;
@@ -211,7 +225,8 @@ public class Block {
         return new Block(
             0,
             "Genesis Block - BlockSmith Blockchain initialized",
-            BlockchainConfig.GENESIS_PREV_HASH
+            BlockchainConfig.GENESIS_PREV_HASH,
+            BlockchainConfig.GENESIS_TIMESTAMP
         );
     }
 

--- a/src/main/java/com/blocksmith/util/BlockchainConfig.java
+++ b/src/main/java/com/blocksmith/util/BlockchainConfig.java
@@ -44,6 +44,15 @@ public final class BlockchainConfig {
     public static final String GENESIS_PREV_HASH = "0";
 
     /**
+     * Fixed creation timestamp for the Genesis block (2024-01-01T00:00:00Z).
+     * The genesis hash must be identical on every node, so it cannot depend on
+     * wall-clock time. With this fixed timestamp, mining (a deterministic nonce
+     * search) yields a byte-identical genesis block network-wide, which lets
+     * independent nodes share a common chain root for broadcast and sync.
+    */
+    public static final long GENESIS_TIMESTAMP = 1704067200000L;
+
+    /**
      * Address used as sender for mining reward transactions.
      * Coinbase transactions create new coins "from nothing".
     */

--- a/src/test/java/com/blocksmith/core/BlockchainTest.java
+++ b/src/test/java/com/blocksmith/core/BlockchainTest.java
@@ -50,10 +50,24 @@ public class BlockchainTest {
     @Test
     @DisplayName("Genesis block hash meets mining difficulty")
     void genesisBlockIsMinedCorrectly() {
-        Block genesis = blockchain.getBlock(0);        
+        Block genesis = blockchain.getBlock(0);
         String target = "0".repeat(BlockchainConfig.MINING_DIFFICULTY);
         assertTrue(genesis.getHash().startsWith(target),
                 "Genesis block hash should start with " + target);
+    }
+
+    @Test
+    @DisplayName("Independent chains share an identical genesis block")
+    void genesisIsDeterministicAcrossInstances() {
+        Block genesisA = new Blockchain().getBlock(0);
+        Block genesisB = new Blockchain().getBlock(0);
+
+        assertEquals(BlockchainConfig.GENESIS_TIMESTAMP, genesisA.getTimestamp(),
+                "Genesis uses the fixed timestamp, not wall-clock time");
+        assertEquals(genesisA.getHash(), genesisB.getHash(),
+                "Two independent nodes must share the same genesis hash");
+        assertEquals(genesisA.getNonce(), genesisB.getNonce(),
+                "Deterministic mining yields the same genesis nonce");
     }
 
     // ==================== ADD BLOCK TESTS ====================


### PR DESCRIPTION
## Summary
Makes the genesis block byte-identical on every node so independent nodes share a common chain root - a prerequisite for Sprint 10 block broadcast / chain sync to work end-to-end in a real multi-node run.

- Add a fixed `GENESIS_TIMESTAMP` (2024-01-01T00:00:00Z) to `BlockchainConfig`.
- Add a `Block(index, data, previousHash, timestamp)` constructor; the existing 3-arg data constructor now delegates to it with `System.currentTimeMillis()` (unchanged behavior for normal blocks).
- `createGenesisBlock()` uses the fixed timestamp. Since mining is a deterministic nonce search, the mined genesis is identical across instances.

## Root cause
Genesis was built with `System.currentTimeMillis()`, and the timestamp feeds `calculateHash()`, so every `new Blockchain()` produced a different genesis hash. A block received from a peer could never link to the local genesis.

## Test plan
- [x] New test: two independent `Blockchain` instances share the same genesis hash and nonce
- [x] `mvn test` green - 156 tests passing

Closes #93