### PR TITLE
docs: Sprint 11 plan (Mempool Sync)

### DIFF
--- a/.ai/sprints/sprint11/github-issues.md
+++ b/.ai/sprints/sprint11/github-issues.md
@@ -1,0 +1,196 @@
+# Sprint 11: GitHub Issues
+
+> Copy each issue to GitHub. Actual issue numbers are assigned on creation
+> (PRs consume the same number space, so they will not be contiguous).
+
+---
+
+## Milestone 11a: Transaction broadcast (NEW_TRANSACTION)
+
+---
+
+### Add Node.broadcastTransaction(Transaction)
+
+**Labels:** `sprint-11`, `milestone-11a`, `enhancement`
+
+**Description:**
+
+Send a received/submitted transaction to every connected peer, mirroring
+`broadcastBlock`.
+
+**New methods in Node.java:**
+```java
+public void broadcastTransaction(Transaction tx)
+public void broadcastTransaction(Transaction tx, String excludeNodeId)
+```
+- Build a `NewTransactionMessage(nodeId, tx)`
+- Write its JSON to every connected peer's writer
+- Skip `excludeNodeId` so a relayed tx is not sent back to its sender
+
+**Acceptance Criteria:**
+- [ ] Sends NEW_TRANSACTION to all connected peers
+- [ ] Sender-exclusion on relay
+- [ ] Compiles with `mvn compile`
+
+---
+
+### Implement NEW_TRANSACTION handler (validate, add, re-gossip)
+
+**Labels:** `sprint-11`, `milestone-11a`, `enhancement`
+
+**Description:**
+
+Register a NEW_TRANSACTION handler in `registerDefaultHandlers()`.
+
+**Handler flow:**
+- Extract the Transaction from `NewTransactionMessage`
+- Add via `blockchain.addTransaction(tx)` (validates signature, balance,
+  rejects COINBASE from users)
+- If newly accepted -> `broadcastTransaction(tx, sender)` to other peers
+- Duplicate/invalid tx returns false -> not relayed (no gossip storm)
+
+**Acceptance Criteria:**
+- [ ] NEW_TRANSACTION handler registered
+- [ ] Valid new tx added and re-gossiped
+- [ ] Duplicate/invalid tx ignored
+- [ ] Compiles with `mvn compile`
+
+---
+
+### Unit tests for transaction broadcast
+
+**Labels:** `sprint-11`, `milestone-11a`, `test`
+
+**Description:**
+
+Reflection-driven handler tests with an in-memory MessageContext, like the
+Sprint 10 broadcast tests.
+
+**Test Cases:**
+1. `newTransactionMessage_roundTripsThroughParser` - serialization
+2. `newTransactionHandler_addsValidTransaction` - pool grows by one
+3. `newTransactionHandler_ignoresDuplicate` - known tx not re-added/relayed
+4. `newTransactionHandler_rejectsInvalidTransaction` - bad tx not added
+
+**Acceptance Criteria:**
+- [ ] Tests added and passing
+- [ ] All existing tests still passing
+- [ ] `mvn test` green
+
+---
+
+## Milestone 11b: Prune confirmed transactions
+
+---
+
+### Remove a block's transactions from the pending pool on append
+
+**Labels:** `sprint-11`, `milestone-11b`, `enhancement`
+
+**Description:**
+
+When a block is appended, drop its transactions from `pendingTransactions`
+so they are never re-mined or re-gossiped.
+
+**Implementation:**
+- Add a helper (e.g. `removeConfirmed(Block)`) called from `addBlock(Block)`
+  and the local mine path
+- Match on transaction id so only confirmed txs are removed
+
+**Acceptance Criteria:**
+- [ ] Confirmed transactions leave the pending pool
+- [ ] Unrelated pending transactions remain
+- [ ] Compiles with `mvn compile`
+
+---
+
+### Unit tests for mempool pruning
+
+**Labels:** `sprint-11`, `milestone-11b`, `test`
+
+**Description:**
+
+**Test Cases:**
+1. `appendingBlock_prunesConfirmedTransactions` - confirmed txs removed
+2. `appendingBlock_keepsUnrelatedPending` - other pending txs untouched
+
+**Acceptance Criteria:**
+- [ ] Tests added and passing
+- [ ] `mvn test` green
+
+---
+
+## Milestone 11c: Mempool sync on connect (GET_MEMPOOL / MEMPOOL)
+
+---
+
+### Add GET_MEMPOOL / MEMPOOL types + message classes
+
+**Labels:** `sprint-11`, `milestone-11c`, `enhancement`
+
+**Description:**
+
+Add request/response messages for fetching a peer's pending transactions.
+
+- `MessageType.GET_MEMPOOL`, `MessageType.MEMPOOL` enum values
+- `GetMempoolMessage(nodeId)`
+- `MempoolMessage(nodeId, List<Transaction>)`
+- Register both in `MessageParser.TYPE_REGISTRY`
+
+**Acceptance Criteria:**
+- [ ] Both message classes + enum values + parser registration
+- [ ] Round-trips through MessageParser
+- [ ] Compiles with `mvn compile`
+
+---
+
+### Implement GET_MEMPOOL / MEMPOOL handlers + request on connect
+
+**Labels:** `sprint-11`, `milestone-11c`, `enhancement`
+
+**Description:**
+
+- GET_MEMPOOL handler: reply with a `MempoolMessage` containing
+  `getPendingTransactions()`
+- MEMPOOL handler: add each received transaction via `addTransaction`
+- After the HELLO handshake, send `GetMempoolMessage` so a fresh node catches
+  up on the current pending set
+
+**Acceptance Criteria:**
+- [ ] GET_MEMPOOL serves the pending pool
+- [ ] MEMPOOL applies received transactions
+- [ ] New connection triggers a mempool request
+- [ ] Compiles with `mvn compile`
+
+---
+
+### Unit tests for mempool sync
+
+**Labels:** `sprint-11`, `milestone-11c`, `test`
+
+**Description:**
+
+**Test Cases:**
+1. `getMempoolMessage_roundTrips` / `mempoolMessage_roundTrips` - serialization
+2. `getMempoolHandler_servesPendingPool` - correct pool returned
+3. `mempoolHandler_appliesReceivedTransactions` - pool catches up
+
+**Acceptance Criteria:**
+- [ ] Tests added and passing
+- [ ] All existing tests still passing
+- [ ] `mvn test` green
+
+---
+
+## Summary
+
+| Milestone | Issues | Tests |
+|-----------|--------|-------|
+| 11a: Transaction broadcast | 3 | 4 tests |
+| 11b: Mempool pruning | 2 | 2 tests |
+| 11c: Mempool sync | 3 | 3 tests |
+| **Total** | **8 issues** | **~9 tests** |
+
+---
+
+*Created: 2026-07-01 | Sprint 11 Planning*

--- a/.ai/sprints/sprint11/sprint-log.md
+++ b/.ai/sprints/sprint11/sprint-log.md
@@ -1,0 +1,36 @@
+# Sprint 11: Mempool Sync - Log
+
+## Sprint Timeline
+
+| Event | Date |
+|-------|------|
+| **Sprint Start** | 2026-07-01 |
+| **Sprint End** | TBD |
+
+---
+
+## Milestone 11a: Transaction broadcast (NEW_TRANSACTION) - Pending
+
+---
+
+## Milestone 11b: Prune confirmed transactions - Pending
+
+---
+
+## Milestone 11c: Mempool sync on connect (GET_MEMPOOL / MEMPOOL) - Pending
+
+---
+
+## Notes
+
+- Continuing issue-first, milestone-per-branch workflow from Sprints 8-10
+- Sprint 10 wrapped at PR #92 (docs); genesis-determinism fix landed at PR #94
+- `NewTransactionMessage` + `NEW_TRANSACTION` already exist and are registered
+  in `MessageParser`; the missing piece is the Node handler (same start as
+  NEW_BLOCK in Sprint 10)
+- 11b (pruning) closes a real gap: mined transactions currently stay in the
+  pending pool and would be re-gossiped/re-mined
+
+---
+
+*Created: 2026-07-01*

--- a/.ai/sprints/sprint11/sprint-plan.md
+++ b/.ai/sprints/sprint11/sprint-plan.md
@@ -1,0 +1,157 @@
+# Sprint 11: Mempool Sync
+
+## Sprint Info
+
+| Field | Value |
+|-------|-------|
+| **Sprint** | 11 |
+| **Title** | Mempool Sync |
+| **Phase** | Phase 2: Network Layer |
+| **Status** | Planning |
+| **Depends On** | Sprint 10 Complete (Block Broadcasting) |
+
+---
+
+## Goal
+
+Give the network a shared view of *pending* transactions. When a node
+receives a transaction it gossips it to every peer; receivers validate it,
+add it to their mempool, and re-broadcast. When a block is appended, its
+transactions are pruned from the mempool so they are never re-mined or
+re-gossiped. A freshly connected node pulls the current mempool from a peer
+so it can start mining with the same pending set. By the end of this sprint
+a transaction submitted anywhere propagates to every node, and confirmed
+transactions cleanly leave the pool.
+
+---
+
+## Milestones
+
+| Milestone | Title | Branch | Status |
+|-----------|-------|--------|--------|
+| **11a** | Transaction broadcast (NEW_TRANSACTION) | `sprint11a/tx-broadcast` | Pending |
+| **11b** | Prune confirmed transactions from the mempool | `sprint11b/mempool-prune` | Pending |
+| **11c** | Mempool sync on connect (GET_MEMPOOL / MEMPOOL) | `sprint11c/mempool-sync` | Pending |
+
+---
+
+## Milestone 11a: Transaction broadcast (NEW_TRANSACTION)
+
+### GitHub Issues
+
+| Issue | Title | Status |
+|-------|-------|--------|
+| TBD | Add Node.broadcastTransaction(Transaction) | Pending |
+| TBD | Implement NEW_TRANSACTION handler (validate, add, re-gossip) | Pending |
+| TBD | Unit tests for transaction broadcast | Pending |
+
+### Deliverables
+
+- [ ] `Node.broadcastTransaction(Transaction)` /
+      `broadcastTransaction(tx, excludeNodeId)` sends a `NewTransactionMessage`
+      to all connected peers (sender-exclusion on relay, like `broadcastBlock`)
+- [ ] NEW_TRANSACTION handler: validate + add via `Blockchain.addTransaction`,
+      and re-gossip only if newly accepted (duplicates/invalid return false ->
+      no relay storm)
+- [ ] Unit tests: parser round-trip, accepted tx re-gossips, duplicate ignored,
+      invalid tx rejected
+
+### Why this is first
+
+`NewTransactionMessage` and the `NEW_TRANSACTION` type already exist and are
+registered in `MessageParser`, but there is **no handler in Node** - the same
+starting point NEW_BLOCK had in Sprint 10. Broadcast is the smallest useful
+increment and mirrors the block-broadcast code directly.
+
+---
+
+## Milestone 11b: Prune confirmed transactions from the mempool
+
+### GitHub Issues
+
+| Issue | Title | Status |
+|-------|-------|--------|
+| TBD | Remove a block's transactions from the pending pool on append | Pending |
+| TBD | Unit tests for mempool pruning | Pending |
+
+### Deliverables
+
+- [ ] `Blockchain.addBlock(Block)` (external append) and the local mine path
+      remove the block's transactions from `pendingTransactions`
+- [ ] Pruning matches on transaction id so only confirmed txs are dropped
+- [ ] Unit tests: confirmed txs leave the pool; unrelated pending txs remain
+
+### Why this matters
+
+Without pruning, a transaction that has already been mined stays in the pool
+and gets re-broadcast forever (and could be mined again into a later block).
+This is a real gap today and underpins the correctness of 11a's gossip.
+
+---
+
+## Milestone 11c: Mempool sync on connect (GET_MEMPOOL / MEMPOOL)
+
+### GitHub Issues
+
+| Issue | Title | Status |
+|-------|-------|--------|
+| TBD | Add GET_MEMPOOL / MEMPOOL types + GetMempoolMessage / MempoolMessage | Pending |
+| TBD | Implement GET_MEMPOOL / MEMPOOL handlers + request on connect | Pending |
+| TBD | Unit tests for mempool sync | Pending |
+
+### Deliverables
+
+- [ ] `MessageType.GET_MEMPOOL`, `MessageType.MEMPOOL` enum values
+- [ ] `GetMempoolMessage(nodeId)` and `MempoolMessage(nodeId, List<Transaction>)`,
+      registered in `MessageParser` (mirrors GET_BLOCKS / BLOCKS)
+- [ ] GET_MEMPOOL handler serves `getPendingTransactions()`; MEMPOOL handler
+      applies each via `addTransaction`
+- [ ] A node requests the mempool after the HELLO handshake so a fresh node
+      catches up on pending transactions
+- [ ] Unit tests: message round-trips, handler serves the pool, received pool
+      is applied
+
+---
+
+## Theory: Transaction Propagation and the Mempool
+
+```
+THEORY: How a transaction reaches every node's mempool
+
+PROBLEM:
+- A user submits a transaction to one node. Every miner must learn about it
+  so it can be included in the next block, no matter who mines it.
+
+BITCOIN'S APPROACH:
+1. Node relays "inv" announcing the new tx id
+2. Peers that don't have it reply "getdata"
+3. Node sends the full "tx"
+4. Each receiver validates (signature, funds, no double-spend) and relays on
+5. When a block confirms the tx, every node removes it from its mempool
+
+OUR SIMPLIFIED MODEL:
+1. Node calls broadcastTransaction() -> NEW_TRANSACTION to all peers (full tx)
+2. Receiver validates and adds via Blockchain.addTransaction(tx)
+3. If newly accepted, receiver re-gossips to its other peers
+4. When a block is appended, its txs are pruned from the pool (11b)
+5. Freshly connected? GET_MEMPOOL / MEMPOOL to fetch the current pending set
+
+DOUBLE-SPEND & VALIDATION:
+- addTransaction already checks signature, balance, and rejects COINBASE
+  from users (Sprints 5-6), so the gossip path reuses that validation
+```
+
+---
+
+## Dependencies
+
+- Sprint 10 Complete (broadcast fan-out, sender-exclusion, handler registry,
+  deterministic genesis so nodes share a chain root)
+- Existing MessageType: NEW_TRANSACTION (registered in MessageParser)
+- Existing message class: NewTransactionMessage (carries a full Transaction)
+- Core: Blockchain.addTransaction(), getPendingTransactions(), Transaction
+  validation/signature verification
+
+---
+
+*Created: 2026-07-01 | Sprint 11 Planning*


### PR DESCRIPTION
## Summary
Plans Sprint 11 (Mempool Sync), the final Phase 2 networking sprint, following the Sprint 10 planning format.

- **sprint-plan.md**: goal, three milestones (11a transaction broadcast, 11b prune confirmed txs, 11c mempool sync on connect), per-milestone deliverables, propagation theory, dependencies.
- **github-issues.md**: full copy-ready issue text for all 8 issues.
- **sprint-log.md**: milestone skeleton for tracking.

## Milestones
- **11a** - NEW_TRANSACTION broadcast/relay (handler is the missing piece; message + type already exist)
- **11b** - prune a block's transactions from the pending pool on append (closes a real gap)
- **11c** - GET_MEMPOOL / MEMPOOL sync so a fresh node catches up on pending txs

## Test plan
- [x] Docs-only change