### PR TITLE
Sprint 11a: Transaction broadcast (NEW_TRANSACTION)

### DIFF
--- a/src/main/java/com/blocksmith/core/Blockchain.java
+++ b/src/main/java/com/blocksmith/core/Blockchain.java
@@ -234,6 +234,15 @@ public class Blockchain {
             return false;
         }
 
+        // Reject duplicates already waiting in the pool. This also stops a
+        // gossiped transaction from being relayed twice (returns false).
+        String txId = transaction.getTransactionId();
+        for (Transaction pending : pendingTransactions) {
+            if (pending.getTransactionId().equals(txId)) {
+                return false;
+            }
+        }
+
         // Check sender has sufficient balance
         double senderBalance = getBalance(transaction.getSender());
         double pendingOutgoing = getPendingOutgoing(transaction.getSender());

--- a/src/main/java/com/blocksmith/network/Node.java
+++ b/src/main/java/com/blocksmith/network/Node.java
@@ -27,8 +27,10 @@ import com.blocksmith.network.messages.HelloMessage;
 import com.blocksmith.network.messages.PingMessage;
 import com.blocksmith.network.messages.PeersMessage;
 import com.blocksmith.network.messages.NewBlockMessage;
+import com.blocksmith.network.messages.NewTransactionMessage;
 import com.blocksmith.network.messages.GetBlocksMessage;
 import com.blocksmith.network.messages.BlocksMessage;
+import com.blocksmith.core.Transaction;
 
 /**
  * THEORY: Network Node - The Heart of P2P
@@ -362,6 +364,20 @@ public class Node {
                         + context.getRemoteNodeId());
             }
         });
+
+        // NEW_TRANSACTION -> validate, add to mempool, and re-gossip if new
+        registerHandler(MessageType.NEW_TRANSACTION, (message, context) -> {
+            Transaction tx = ((NewTransactionMessage) message).getTransaction();
+            if (tx == null) return;
+
+            // addTransaction() returns false for duplicates and invalid txs, so
+            // a transaction is only relayed once - this stops gossip storms.
+            if (blockchain.addTransaction(tx)) {
+                System.out.println("  ← Accepted NEW_TRANSACTION from "
+                        + context.getRemoteNodeId());
+                broadcastTransaction(tx, context.getRemoteNodeId());
+            }
+        });
     }
 
     /**
@@ -388,6 +404,35 @@ public class Node {
         if (block == null) return;
 
         String json = new NewBlockMessage(nodeId, block).toJson();
+        for (PeerInfo peer : peerManager.getConnectedPeers()) {
+            if (excludeNodeId != null && excludeNodeId.equals(peer.getNodeId())) continue;
+            PrintWriter writer = peerWriters.get(peer.getAddress());
+            if (writer != null) writer.println(json);
+        }
+    }
+
+    /**
+     * Broadcasts a transaction to every connected peer.
+     *
+     * @param tx the transaction to announce
+     */
+    public void broadcastTransaction(Transaction tx) {
+        broadcastTransaction(tx, null);
+    }
+
+    /**
+     * Announces a transaction to all connected peers via NEW_TRANSACTION.
+     * Each receiver validates, adds it to its mempool, and relays it onward,
+     * so the transaction floods the network. When relaying, we exclude the
+     * peer we received it from to avoid bouncing it straight back.
+     *
+     * @param tx the transaction to announce
+     * @param excludeNodeId nodeId of a peer to skip (the sender on relay), or null
+     */
+    public void broadcastTransaction(Transaction tx, String excludeNodeId) {
+        if (tx == null) return;
+
+        String json = new NewTransactionMessage(nodeId, tx).toJson();
         for (PeerInfo peer : peerManager.getConnectedPeers()) {
             if (excludeNodeId != null && excludeNodeId.equals(peer.getNodeId())) continue;
             PrintWriter writer = peerWriters.get(peer.getAddress());

--- a/src/test/java/com/blocksmith/network/TransactionBroadcastTest.java
+++ b/src/test/java/com/blocksmith/network/TransactionBroadcastTest.java
@@ -1,0 +1,124 @@
+package com.blocksmith.network;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.blocksmith.core.Blockchain;
+import com.blocksmith.core.Transaction;
+import com.blocksmith.network.messages.NewTransactionMessage;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for transaction broadcasting - NewTransactionMessage serialization and
+ * the NEW_TRANSACTION handler in Node (validate, add to mempool, ignore
+ * duplicates, reject invalid).
+ *
+ * The handler is registered in the Node constructor, so the node is never
+ * started: the test pulls the handler out of the registry by reflection and
+ * drives it directly with an in-memory MessageContext.
+ */
+@DisplayName("Transaction Broadcast Tests")
+class TransactionBroadcastTest {
+
+    private Node node;
+
+    private static final int TEST_PORT_BASE = 20000;
+    private static int portCounter = 0;
+
+    private int getNextPort() {
+        return TEST_PORT_BASE + (portCounter++);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (node != null) {
+            node.stop();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private MessageHandler getHandler(Node target, MessageType type) throws Exception {
+        Field handlersField = Node.class.getDeclaredField("handlers");
+        handlersField.setAccessible(true);
+        Map<MessageType, MessageHandler> handlers =
+                (Map<MessageType, MessageHandler>) handlersField.get(target);
+        return handlers.get(type);
+    }
+
+    private MessageContext sinkContext(String remoteNodeId) {
+        return new MessageContext(new PrintWriter(new StringWriter()), remoteNodeId);
+    }
+
+    /** Funds an address by mining a block so its coinbase reward is spendable. */
+    private void fund(Blockchain chain, String address) {
+        chain.minePendingTransactions(address);
+    }
+
+    @Test
+    @DisplayName("NewTransactionMessage round-trips through MessageParser")
+    void newTransactionMessage_roundTripsThroughParser() {
+        Transaction tx = new Transaction("Alice", "Bob", 10.0);
+        String json = new NewTransactionMessage("node-1", tx).toJson();
+
+        Message parsed = MessageParser.parse(json);
+
+        assertInstanceOf(NewTransactionMessage.class, parsed,
+                "Should parse as NewTransactionMessage");
+        assertEquals(tx.getTransactionId(),
+                ((NewTransactionMessage) parsed).getTransaction().getTransactionId(),
+                "Transaction id should survive the round trip");
+    }
+
+    @Test
+    @DisplayName("NEW_TRANSACTION handler adds a valid transaction")
+    void newTransactionHandler_addsValidTransaction() throws Exception {
+        node = new Node(getNextPort());
+        Blockchain chain = node.getBlockchain();
+        fund(chain, "Miner1");
+        Transaction tx = new Transaction("Miner1", "Alice", 30.0);
+
+        getHandler(node, MessageType.NEW_TRANSACTION)
+                .handle(new NewTransactionMessage("sender", tx), sinkContext("sender"));
+
+        assertEquals(1, chain.getPendingTransactions().size(),
+                "Valid transaction should be added to the mempool");
+    }
+
+    @Test
+    @DisplayName("NEW_TRANSACTION handler ignores a duplicate transaction")
+    void newTransactionHandler_ignoresDuplicate() throws Exception {
+        node = new Node(getNextPort());
+        Blockchain chain = node.getBlockchain();
+        fund(chain, "Miner1");
+        Transaction tx = new Transaction("Miner1", "Alice", 30.0);
+        MessageHandler handler = getHandler(node, MessageType.NEW_TRANSACTION);
+
+        handler.handle(new NewTransactionMessage("sender", tx), sinkContext("sender")); // accepted
+        handler.handle(new NewTransactionMessage("sender", tx), sinkContext("sender")); // duplicate
+
+        assertEquals(1, chain.getPendingTransactions().size(),
+                "Duplicate transaction should not be added a second time");
+    }
+
+    @Test
+    @DisplayName("NEW_TRANSACTION handler rejects an invalid transaction")
+    void newTransactionHandler_rejectsInvalidTransaction() throws Exception {
+        node = new Node(getNextPort());
+        Blockchain chain = node.getBlockchain();
+        // "Nobody" has no balance, so the transfer has insufficient funds.
+        Transaction tx = new Transaction("Nobody", "Alice", 100.0);
+
+        getHandler(node, MessageType.NEW_TRANSACTION)
+                .handle(new NewTransactionMessage("sender", tx), sinkContext("sender"));
+
+        assertEquals(0, chain.getPendingTransactions().size(),
+                "Invalid transaction must not be added");
+    }
+}


### PR DESCRIPTION
## Summary
First milestone of Sprint 11 (Mempool Sync). Transactions now propagate across the peer network, mirroring the Sprint 10 block-broadcast path.

- Add `Node.broadcastTransaction(Transaction)` / `broadcastTransaction(tx, excludeNodeId)` with sender-exclusion on relay.
- Register a `NEW_TRANSACTION` handler: validate + add via `Blockchain.addTransaction`, and re-gossip only if newly accepted.
- Add an id-based duplicate guard to `Blockchain.addTransaction` so a gossiped transaction is added (and relayed) at most once - this stops relay storms.
- 4 new tests (`TransactionBroadcastTest`): parser round-trip, add valid, ignore duplicate, reject invalid.

## Test plan
- [x] `mvn test` green - 160 tests passing
- [x] `mvn compile` clean

Closes #96
Closes #97
Closes #98