### PR TITLE
Sprint 11b: Prune confirmed transactions from the mempool

### DIFF
--- a/src/main/java/com/blocksmith/core/Blockchain.java
+++ b/src/main/java/com/blocksmith/core/Blockchain.java
@@ -4,9 +4,11 @@ import com.blocksmith.util.BlockchainConfig;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Manages the blockchain - a linked list of blocks.
@@ -149,6 +151,7 @@ public class Blockchain {
         if (block.getIndex() == tip.getIndex() + 1
                 && block.getPreviousHash().equals(tip.getHash())) {
             chain.add(block);
+            removeConfirmed(block);
             attachOrphans();
             return true;
         }
@@ -187,10 +190,30 @@ public class Blockchain {
             orphans.remove(tip.getHash());
             if (child.getIndex() == tip.getIndex() + 1 && isWellFormed(child)) {
                 chain.add(child);
+                removeConfirmed(child);
             } else {
                 break; // stale/ill-fitting orphan: drop and stop
             }
         }
+    }
+
+    /**
+     * Removes a newly-appended block's transactions from the pending pool.
+     *
+     * A transaction gossiped to us earlier may still be sitting in our mempool
+     * when the block that confirms it arrives from a peer. Without this it
+     * would linger and be re-gossiped, or even mined again into a later block.
+     * The local mine path clears the whole pool itself, so this covers the
+     * externally-appended (network) case.
+     */
+    private void removeConfirmed(Block block) {
+        if (block.getTransactions().isEmpty()) return;
+
+        Set<String> confirmedIds = new HashSet<>();
+        for (Transaction tx : block.getTransactions()) {
+            confirmedIds.add(tx.getTransactionId());
+        }
+        pendingTransactions.removeIf(tx -> confirmedIds.contains(tx.getTransactionId()));
     }
 
     /**

--- a/src/test/java/com/blocksmith/core/MempoolPruneTest.java
+++ b/src/test/java/com/blocksmith/core/MempoolPruneTest.java
@@ -1,0 +1,69 @@
+package com.blocksmith.core;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.blocksmith.util.BlockchainConfig;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests that appending an externally-mined block prunes its transactions from
+ * the pending pool - a transaction gossiped to us earlier must not linger once
+ * a block confirms it (Milestone 11b).
+ */
+@DisplayName("Mempool Prune Tests")
+class MempoolPruneTest {
+
+    private Blockchain blockchain;
+
+    @BeforeEach
+    void setUp() {
+        blockchain = new Blockchain();
+        // Fund "Miner1" so it can send spendable transactions.
+        blockchain.minePendingTransactions("Miner1");
+    }
+
+    /** Builds a valid, mined block carrying the given transactions on the tip. */
+    private Block mineBlockWith(List<Transaction> transactions) {
+        Block tip = blockchain.getLatestBlock();
+        Block block = new Block(tip.getIndex() + 1, transactions, tip.getHash());
+        block.mineBlock(BlockchainConfig.MINING_DIFFICULTY);
+        return block;
+    }
+
+    @Test
+    @DisplayName("Appending a block prunes its transactions from the pending pool")
+    void appendingBlock_prunesConfirmedTransactions() {
+        Transaction tx = new Transaction("Miner1", "Alice", 30.0);
+        assertTrue(blockchain.addTransaction(tx), "Transaction should enter the pool");
+        assertEquals(1, blockchain.getPendingTransactions().size(), "Pool holds the tx");
+
+        // A peer's block confirming that same transaction arrives.
+        Block block = mineBlockWith(List.of(tx));
+        assertTrue(blockchain.addBlock(block), "Block extends the tip and is appended");
+
+        assertEquals(0, blockchain.getPendingTransactions().size(),
+                "Confirmed transaction should be removed from the pool");
+    }
+
+    @Test
+    @DisplayName("Appending a block keeps unrelated pending transactions")
+    void appendingBlock_keepsUnrelatedPending() {
+        Transaction pending = new Transaction("Miner1", "Alice", 30.0);
+        assertTrue(blockchain.addTransaction(pending), "Pending tx should enter the pool");
+
+        // The incoming block confirms a different transaction.
+        Transaction other = new Transaction("Miner1", "Bob", 10.0);
+        Block block = mineBlockWith(List.of(other));
+        assertTrue(blockchain.addBlock(block), "Block extends the tip and is appended");
+
+        List<Transaction> pool = blockchain.getPendingTransactions();
+        assertEquals(1, pool.size(), "Unrelated pending tx should remain");
+        assertEquals(pending.getTransactionId(), pool.get(0).getTransactionId(),
+                "The surviving tx should be the unrelated one");
+    }
+}


### PR DESCRIPTION
## Summary
When a block arrives from the network, its transactions are now removed from the pending pool, so a gossiped transaction can't linger and be re-broadcast (or re-mined) after it has been confirmed.

- Add `Blockchain.removeConfirmed(Block)` (matches by transaction id), called after every external append: `addBlock(Block)` and each orphan attached in `attachOrphans()`.
- The local mine path (`minePendingTransactions`) already clears the whole pool, so this closes the remaining gap - the network-appended case.
- 2 new tests (`MempoolPruneTest`): confirmed tx is pruned; an unrelated pending tx survives.

## Why
Without pruning, a transaction we received via NEW_TRANSACTION gossip stays in our mempool even after a peer's block confirms it. This underpins the correctness of 11a's transaction broadcast.

## Test plan
- [x] `mvn test` green - 162 tests passing
- [x] `mvn compile` clean

Closes #100
Closes #101