### PR TITLE
Sprint 11c: Mempool sync on connect (GET_MEMPOOL / MEMPOOL)

### DIFF
--- a/src/main/java/com/blocksmith/network/MessageParser.java
+++ b/src/main/java/com/blocksmith/network/MessageParser.java
@@ -5,8 +5,10 @@ import java.util.Map;
 
 import com.blocksmith.network.messages.BlocksMessage;
 import com.blocksmith.network.messages.GetBlocksMessage;
+import com.blocksmith.network.messages.GetMempoolMessage;
 import com.blocksmith.network.messages.GetPeersMessage;
 import com.blocksmith.network.messages.HelloMessage;
+import com.blocksmith.network.messages.MempoolMessage;
 import com.blocksmith.network.messages.NewBlockMessage;
 import com.blocksmith.network.messages.NewTransactionMessage;
 import com.blocksmith.network.messages.PeersMessage;
@@ -59,6 +61,8 @@ public class MessageParser {
         TYPE_REGISTRY.put(MessageType.PEERS, PeersMessage.class);
         TYPE_REGISTRY.put(MessageType.GET_BLOCKS, GetBlocksMessage.class);
         TYPE_REGISTRY.put(MessageType.BLOCKS, BlocksMessage.class);
+        TYPE_REGISTRY.put(MessageType.GET_MEMPOOL, GetMempoolMessage.class);
+        TYPE_REGISTRY.put(MessageType.MEMPOOL, MempoolMessage.class);
     }
 
     /**

--- a/src/main/java/com/blocksmith/network/MessageType.java
+++ b/src/main/java/com/blocksmith/network/MessageType.java
@@ -46,7 +46,14 @@ public enum MessageType {
 
     /** Request the length of the chain */
     GET_CHAIN_LENGTH,
-    
+
+    // === Mempool synchronization ===
+    /** Request the peer's pending transactions (mempool) */
+    GET_MEMPOOL,
+
+    /** Response with the pending transactions */
+    MEMPOOL,
+
     // === Broadcasting ===
     /** Broadcast a newly mined or received block */
     NEW_BLOCK,

--- a/src/main/java/com/blocksmith/network/Node.java
+++ b/src/main/java/com/blocksmith/network/Node.java
@@ -30,6 +30,8 @@ import com.blocksmith.network.messages.NewBlockMessage;
 import com.blocksmith.network.messages.NewTransactionMessage;
 import com.blocksmith.network.messages.GetBlocksMessage;
 import com.blocksmith.network.messages.BlocksMessage;
+import com.blocksmith.network.messages.GetMempoolMessage;
+import com.blocksmith.network.messages.MempoolMessage;
 import com.blocksmith.core.Transaction;
 
 /**
@@ -378,6 +380,27 @@ public class Node {
                 broadcastTransaction(tx, context.getRemoteNodeId());
             }
         });
+
+        // GET_MEMPOOL -> serve our current pending transactions
+        registerHandler(MessageType.GET_MEMPOOL, (message, context) -> {
+            List<Transaction> pending = new ArrayList<>(blockchain.getPendingTransactions());
+            context.sendMessage(new MempoolMessage(nodeId, pending));
+        });
+
+        // MEMPOOL -> add received pending transactions to our pool
+        registerHandler(MessageType.MEMPOOL, (message, context) -> {
+            List<Transaction> txs = ((MempoolMessage) message).getTransactions();
+            if (txs == null) return;
+
+            int added = 0;
+            for (Transaction tx : txs) {
+                if (blockchain.addTransaction(tx)) added++;
+            }
+            if (added > 0) {
+                System.out.println("  ← Synced " + added + " mempool tx(s) from "
+                        + context.getRemoteNodeId());
+            }
+        });
     }
 
     /**
@@ -635,6 +658,11 @@ public class Node {
 
         outboundPeers.add(peer);
         System.out.println("  ✓ Outbound connection established to " + address);
+
+        // Catch up on the peer's pending transactions now that we're connected.
+        new PrintWriter(peer.getOutputStream(), true)
+                .println(new GetMempoolMessage(nodeId).toJson());
+
         return peer;
     }
 

--- a/src/main/java/com/blocksmith/network/messages/GetMempoolMessage.java
+++ b/src/main/java/com/blocksmith/network/messages/GetMempoolMessage.java
@@ -1,0 +1,19 @@
+package com.blocksmith.network.messages;
+
+import com.blocksmith.network.Message;
+import com.blocksmith.network.MessageType;
+
+/**
+ * Request a peer's pending transactions (mempool). Sent by a freshly connected
+ * node so it can catch up on transactions that are waiting to be mined; the
+ * peer answers with a {@link MempoolMessage}.
+ */
+public class GetMempoolMessage extends Message {
+
+    public GetMempoolMessage(String nodeId) {
+        super(MessageType.GET_MEMPOOL, nodeId);
+    }
+
+    /** Default constructor for Gson. */
+    public GetMempoolMessage() {}
+}

--- a/src/main/java/com/blocksmith/network/messages/MempoolMessage.java
+++ b/src/main/java/com/blocksmith/network/messages/MempoolMessage.java
@@ -1,0 +1,26 @@
+package com.blocksmith.network.messages;
+
+import java.util.List;
+
+import com.blocksmith.core.Transaction;
+import com.blocksmith.network.Message;
+import com.blocksmith.network.MessageType;
+
+/**
+ * Carries a peer's pending transactions in reply to a {@link GetMempoolMessage}.
+ * The receiver validates and adds each one to its own mempool.
+ */
+public class MempoolMessage extends Message {
+
+    private List<Transaction> transactions;
+
+    public MempoolMessage(String nodeId, List<Transaction> transactions) {
+        super(MessageType.MEMPOOL, nodeId);
+        this.transactions = transactions;
+    }
+
+    /** Default constructor for Gson. */
+    public MempoolMessage() {}
+
+    public List<Transaction> getTransactions() { return transactions; }
+}

--- a/src/test/java/com/blocksmith/network/MempoolSyncTest.java
+++ b/src/test/java/com/blocksmith/network/MempoolSyncTest.java
@@ -1,0 +1,138 @@
+package com.blocksmith.network;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.blocksmith.core.Blockchain;
+import com.blocksmith.core.Transaction;
+import com.blocksmith.network.messages.GetMempoolMessage;
+import com.blocksmith.network.messages.MempoolMessage;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for mempool sync - GET_MEMPOOL/MEMPOOL serialization and the handlers
+ * in Node that serve the pending pool and apply a received pool.
+ *
+ * The node is never started: the handler is pulled from the registry by
+ * reflection and driven with a capturing MessageContext.
+ */
+@DisplayName("Mempool Sync Tests")
+class MempoolSyncTest {
+
+    private Node node;
+
+    private static final int TEST_PORT_BASE = 20100;
+    private static int portCounter = 0;
+
+    private int getNextPort() {
+        return TEST_PORT_BASE + (portCounter++);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (node != null) {
+            node.stop();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private MessageHandler getHandler(Node target, MessageType type) throws Exception {
+        Field handlersField = Node.class.getDeclaredField("handlers");
+        handlersField.setAccessible(true);
+        Map<MessageType, MessageHandler> handlers =
+                (Map<MessageType, MessageHandler>) handlersField.get(target);
+        return handlers.get(type);
+    }
+
+    /** A MessageContext that captures the message the handler sends back. */
+    private static class CapturingContext extends MessageContext {
+        final AtomicReference<Message> sent = new AtomicReference<>();
+
+        CapturingContext(String remoteNodeId) {
+            super(null, remoteNodeId);
+        }
+
+        @Override
+        public void sendMessage(Message message) {
+            sent.set(message);
+        }
+    }
+
+    /** Funds an address so it can send spendable transactions. */
+    private void fund(Blockchain chain, String address) {
+        chain.minePendingTransactions(address);
+    }
+
+    @Test
+    @DisplayName("GetMempoolMessage round-trips through MessageParser")
+    void getMempoolMessage_roundTrips() {
+        String json = new GetMempoolMessage("node-1").toJson();
+
+        Message parsed = MessageParser.parse(json);
+
+        assertInstanceOf(GetMempoolMessage.class, parsed, "Should parse as GetMempoolMessage");
+        assertEquals("node-1", parsed.getNodeId(), "nodeId should survive the round trip");
+    }
+
+    @Test
+    @DisplayName("MempoolMessage round-trips through MessageParser")
+    void mempoolMessage_roundTrips() {
+        Transaction tx = new Transaction("Alice", "Bob", 10.0);
+        String json = new MempoolMessage("node-1", List.of(tx)).toJson();
+
+        Message parsed = MessageParser.parse(json);
+
+        assertInstanceOf(MempoolMessage.class, parsed, "Should parse as MempoolMessage");
+        List<Transaction> received = ((MempoolMessage) parsed).getTransactions();
+        assertEquals(1, received.size(), "The transaction should survive the round trip");
+        assertEquals(tx.getTransactionId(), received.get(0).getTransactionId(),
+                "Transaction id should match");
+    }
+
+    @Test
+    @DisplayName("GET_MEMPOOL handler serves the pending pool")
+    void getMempoolHandler_servesPendingPool() throws Exception {
+        node = new Node(getNextPort());
+        Blockchain chain = node.getBlockchain();
+        fund(chain, "Miner1");
+        Transaction tx = new Transaction("Miner1", "Alice", 30.0);
+        assertTrue(chain.addTransaction(tx), "Setup tx should enter the pool");
+
+        CapturingContext context = new CapturingContext("requester");
+        getHandler(node, MessageType.GET_MEMPOOL)
+                .handle(new GetMempoolMessage("requester"), context);
+
+        Message reply = context.sent.get();
+        assertInstanceOf(MempoolMessage.class, reply, "Reply should be a MempoolMessage");
+        List<Transaction> served = ((MempoolMessage) reply).getTransactions();
+        assertEquals(1, served.size(), "Should serve the one pending transaction");
+        assertEquals(tx.getTransactionId(), served.get(0).getTransactionId(),
+                "Served tx should be the pending one");
+    }
+
+    @Test
+    @DisplayName("MEMPOOL handler applies received transactions")
+    void mempoolHandler_appliesReceivedTransactions() throws Exception {
+        node = new Node(getNextPort());
+        Blockchain chain = node.getBlockchain();
+        fund(chain, "Miner1"); // fund so the received tx is valid on our chain
+        assertEquals(0, chain.getPendingTransactions().size(), "Pool starts empty");
+
+        Transaction tx = new Transaction("Miner1", "Alice", 30.0);
+        getHandler(node, MessageType.MEMPOOL)
+                .handle(new MempoolMessage("sender", List.of(tx)), new CapturingContext("sender"));
+
+        assertEquals(1, chain.getPendingTransactions().size(),
+                "Received transaction should be added to the pool");
+        assertEquals(tx.getTransactionId(),
+                chain.getPendingTransactions().get(0).getTransactionId(),
+                "The added tx should be the received one");
+    }
+}


### PR DESCRIPTION
## Summary
Final milestone of Sprint 11. A freshly connected node now pulls a peer's pending transactions so it can start mining with the same mempool - mirroring the Sprint 10 GET_BLOCKS/BLOCKS chain sync.

- Add `MessageType.GET_MEMPOOL` / `MEMPOOL` and `GetMempoolMessage(nodeId)` / `MempoolMessage(nodeId, List<Transaction>)`, registered in `MessageParser`.
- `GET_MEMPOOL` handler serves `getPendingTransactions()`; `MEMPOOL` handler applies each received tx via `addTransaction` (validation + dedupe already handle invalid/duplicate).
- `connectToPeer` sends a `GetMempoolMessage` right after the handshake so a new outbound connection catches up.
- 4 new tests (`MempoolSyncTest`): both message round-trips, handler serves the pool, handler applies a received pool.

## Test plan
- [x] `mvn test` green - 166 tests passing
- [x] `mvn compile` clean

Closes #103
Closes #104
Closes #105