### PR TITLE
docs: Sprint 11 & Phase 2 complete (Mempool Sync)

### DIFF
--- a/.ai/STATUS.md
+++ b/.ai/STATUS.md
@@ -8,10 +8,10 @@
 
 | Field | Value |
 |-------|-------|
-| **Phase** | 2 - Network Layer |
-| **Current Sprint** | 10 (Block Broadcasting) - Complete |
-| **Current Milestone** | 10d Complete (Chain Sync) |
-| **Status** | Sprint 10 complete (10a-10d), next: Sprint 11 (Mempool Sync) |
+| **Phase** | 2 - Network Layer - Complete |
+| **Current Sprint** | 11 (Mempool Sync) - Complete |
+| **Current Milestone** | 11c Complete (Mempool sync on connect) |
+| **Status** | Phase 2 complete (Sprints 8-11), next: Phase 3 (API & Interface) |
 
 ---
 
@@ -40,11 +40,13 @@ Phase 1: Core Blockchain     [███████████████] 100
 ├── Sprint 5: Wallets        ✅
 └── Sprint 6: Economics      ✅
 
-Phase 2: Network Layer       [███████████░░░░] 75% ← CURRENT
+Phase 2: Network Layer       [███████████████] 100% ✅ COMPLETE
 ├── Sprint 8: P2P Networking ✅ COMPLETE (8a ✅, 8b ✅, 8c ✅, 8d ✅)
 ├── Sprint 9: Node Discovery ✅ COMPLETE (9a ✅, 9b ✅, 9c ✅, 9d ✅)
 ├── Sprint 10: Broadcasting  ✅ COMPLETE (10a ✅, 10b ✅, 10c ✅, 10d ✅)
-└── Sprint 11: Mempool Sync  ⬜ ← NEXT
+└── Sprint 11: Mempool Sync  ✅ COMPLETE (11a ✅, 11b ✅, 11c ✅)
+
+Phase 3: API & Interface     [░░░░░░░░░░░░░░░] 0% ← NEXT
 ```
 
 ---
@@ -55,7 +57,7 @@ Phase 2: Network Layer       [███████████░░░░] 75%
 |------------|-------|--------|
 | HashUtilTest | 6 | ✅ |
 | BlockTest | 12 | ✅ |
-| BlockchainTest | 25 | ✅ |
+| BlockchainTest | 26 | ✅ |
 | MiningTest | 9 | ✅ |
 | TransactionTest | 22 | ✅ |
 | WalletTest | 13 | ✅ |
@@ -72,7 +74,10 @@ Phase 2: Network Layer       [███████████░░░░] 75%
 | BlockBroadcastTest | 4 | ✅ |
 | OrphanBlockTest | 3 | ✅ |
 | ChainSyncTest | 5 | ✅ |
-| **Total** | **155** | ✅ |
+| TransactionBroadcastTest | 4 | ✅ |
+| MempoolPruneTest | 2 | ✅ |
+| MempoolSyncTest | 4 | ✅ |
+| **Total** | **166** | ✅ |
 
 Last test run: `mvn test` - All passing
 
@@ -85,7 +90,7 @@ Last test run: `mvn test` - All passing
 | Class | Status | Lines | Notes |
 |-------|--------|-------|-------|
 | Block.java | ✅ Complete | ~268 | Transactions + Merkle root |
-| Blockchain.java | ✅ Complete | ~470 | Pending pool + mining + external append + orphan buffer (Sprint 10) |
+| Blockchain.java | ✅ Complete | ~495 | Pending pool + mining + external append + orphan buffer (Sprint 10) + tx dedupe + mempool prune (Sprint 11) |
 | Transaction.java | ✅ Complete | ~200 | Validation + signing + verification |
 | Wallet.java | ✅ Complete | ~169 | ECDSA keys + signing |
 
@@ -104,7 +109,7 @@ Last test run: `mvn test` - All passing
 | MessageType.java | ✅ Complete | ~45 | Message types enum |
 | Message.java | ✅ Complete | ~82 | Base message class |
 | NetworkConfig.java | ✅ Complete | ~103 | Network constants + heartbeat + seed nodes |
-| Node.java | ✅ Complete | ~595 | Server + message loop + peer tracking + heartbeat eviction + peer discovery + seed bootstrap + block broadcast + chain sync (Sprint 10) |
+| Node.java | ✅ Complete | ~650 | Server + message loop + peer tracking + heartbeat eviction + peer discovery + seed bootstrap + block broadcast + chain sync (Sprint 10) + tx broadcast + mempool sync (Sprint 11) |
 | Peer.java | ✅ Complete | ~294 | Client + async listener thread |
 | MessageParser.java | ✅ Complete | ~116 | JSON-to-Message routing (Sprint 8d) |
 | MessageHandler.java | ✅ Complete | ~36 | Handler functional interface (Sprint 8d) |
@@ -113,7 +118,7 @@ Last test run: `mvn test` - All passing
 | PeerState.java | ✅ Complete | ~43 | Peer connection lifecycle enum (Sprint 9a) |
 | PeerInfo.java | ✅ Complete | ~110 | Peer metadata tracking (Sprint 9a) |
 | PeerManager.java | ✅ Complete | ~145 | Peer registry, MAX_PEERS enforcement (Sprint 9b) |
-| messages/*.java | ✅ Complete | ~230 | 9 concrete message types (+ GetBlocks/Blocks, Sprint 10d) |
+| messages/*.java | ✅ Complete | ~280 | 11 concrete message types (+ GetMempool/Mempool, Sprint 11c) |
 
 ### Demo
 
@@ -170,6 +175,12 @@ Last test run: `mvn test` - All passing
 - [x] Bounded orphan buffer with attach-on-parent-arrival (Sprint 10c)
 - [x] GetBlocksMessage / BlocksMessage for chain sync (Sprint 10d)
 - [x] GET_BLOCKS / BLOCKS handlers + behind-peer sync trigger (Sprint 10d)
+- [x] Deterministic genesis block (fixed timestamp, shared chain root)
+- [x] Node.broadcastTransaction + NEW_TRANSACTION validate/add/re-gossip (Sprint 11a)
+- [x] Transaction dedupe in the mempool to stop gossip storms (Sprint 11a)
+- [x] Prune confirmed transactions from the mempool on append (Sprint 11b)
+- [x] GetMempoolMessage / MempoolMessage for mempool sync (Sprint 11c)
+- [x] GET_MEMPOOL / MEMPOOL handlers + mempool request on connect (Sprint 11c)
 
 ---
 
@@ -178,7 +189,7 @@ Last test run: `mvn test` - All passing
 | Item | Value |
 |------|-------|
 | **Current Branch** | `master` |
-| **Last Commit** | Sprint 10 complete (chain sync merged, PR #91) |
+| **Last Commit** | Sprint 11 complete (mempool sync merged, PR #106) |
 | **Tag** | `v1.0.0` (Phase 1) |
 | **Main Branch** | `master` |
 
@@ -192,20 +203,25 @@ _None currently._
 
 ## 📝 Notes for Next Session
 
-1. **Sprint 10 COMPLETE** - Block Broadcasting
-   - All milestones 10a, 10b, 10c, 10d merged to master
-   - Block gossip (NEW_BLOCK), orphan buffering, and chain sync (GET_BLOCKS/BLOCKS) live
-   - Node now carries a real Blockchain; HELLO reports the true chain length
+1. **Sprint 11 COMPLETE** - Mempool Sync
+   - All milestones 11a, 11b, 11c merged to master
+   - Transaction gossip (NEW_TRANSACTION), confirmed-tx pruning, and mempool
+     sync on connect (GET_MEMPOOL/MEMPOOL) live
+   - Genesis block is now deterministic, so nodes share a common chain root
 
-2. **Next: Sprint 11** - Mempool Sync
-   - Gossip pending transactions across the peer network
+2. **Phase 2 COMPLETE** - Network Layer (Sprints 8-11)
+   - P2P networking, node discovery, block broadcasting, mempool sync all done
 
-3. **Deferred / future work**
-   - Deterministic genesis block (current genesis uses a wall-clock timestamp,
-     so independent nodes cannot sync in a real multi-node demo)
+3. **Next: Phase 3** - API & Interface
+   - REST API, dashboard/block explorer, and related tooling (Sprints 12+)
+   - Plan Sprint 12 to kick off the phase
+
+4. **Deferred / future work**
    - Gossip auto-connect to DISCOVERED peers (needs MAX_PEERS guarding)
    - Self-identification filtering in peer lists
+   - Mempool request is sent on outbound connect only; inbound side does not
+     yet pull the peer's mempool
 
 ---
 
-*Last updated: 2026-06-30 | Sprint 10 Complete (Milestone 10d)*
+*Last updated: 2026-07-02 | Sprint 11 Complete (Milestone 11c) - Phase 2 Complete*

--- a/.ai/sprints/sprint11/sprint-log.md
+++ b/.ai/sprints/sprint11/sprint-log.md
@@ -5,32 +5,66 @@
 | Event | Date |
 |-------|------|
 | **Sprint Start** | 2026-07-01 |
-| **Sprint End** | TBD |
+| **Sprint End** | 2026-07-02 |
 
 ---
 
-## Milestone 11a: Transaction broadcast (NEW_TRANSACTION) - Pending
+## Milestone 11a: Transaction broadcast (NEW_TRANSACTION) - Complete
+
+- Added `Node.broadcastTransaction(Transaction)` /
+  `broadcastTransaction(tx, excludeNodeId)` with sender-exclusion on relay
+- NEW_TRANSACTION handler validates via `addTransaction`, adds to the mempool,
+  and re-gossips only if newly accepted
+- Added an id-based duplicate guard to `Blockchain.addTransaction` so a gossiped
+  transaction is added (and relayed) at most once - stops relay storms
+- Issues #96, #97, #98 - merged via PR #99
+- Tests: `TransactionBroadcastTest` (4)
 
 ---
 
-## Milestone 11b: Prune confirmed transactions - Pending
+## Milestone 11b: Prune confirmed transactions - Complete
+
+- Added `Blockchain.removeConfirmed(Block)` (matches by transaction id), called
+  after every external append: `addBlock(Block)` and each orphan in `attachOrphans()`
+- The local mine path already clears the whole pool, so this closed the
+  network-appended gap
+- Issues #100, #101 - merged via PR #102
+- Tests: `MempoolPruneTest` (2)
 
 ---
 
-## Milestone 11c: Mempool sync on connect (GET_MEMPOOL / MEMPOOL) - Pending
+## Milestone 11c: Mempool sync on connect (GET_MEMPOOL / MEMPOOL) - Complete
+
+- Added `GET_MEMPOOL` / `MEMPOOL` types and `GetMempoolMessage(nodeId)` /
+  `MempoolMessage(nodeId, transactions)`, registered in `MessageParser`
+- GET_MEMPOOL handler serves `getPendingTransactions()`; MEMPOOL handler applies
+  each received tx via `addTransaction`
+- `connectToPeer` sends a `GetMempoolMessage` right after the handshake so a new
+  outbound connection catches up
+- Issues #103, #104, #105 - merged via PR #106
+- Tests: `MempoolSyncTest` (4)
+
+---
+
+## Outcome
+
+- **Sprint 11 complete** (11a-11c): transactions now propagate across the peer
+  network, confirmed transactions are pruned from the mempool, and a freshly
+  connected node pulls the peer's pending set
+- **Phase 2 (Network Layer) complete** (Sprints 8-11)
+- Test count: 155 -> 166 (+11, including the deterministic-genesis test)
 
 ---
 
 ## Notes
 
-- Continuing issue-first, milestone-per-branch workflow from Sprints 8-10
-- Sprint 10 wrapped at PR #92 (docs); genesis-determinism fix landed at PR #94
-- `NewTransactionMessage` + `NEW_TRANSACTION` already exist and are registered
-  in `MessageParser`; the missing piece is the Node handler (same start as
-  NEW_BLOCK in Sprint 10)
-- 11b (pruning) closes a real gap: mined transactions currently stay in the
-  pending pool and would be re-gossiped/re-mined
+- Continued issue-first, milestone-per-branch workflow from Sprints 8-10
+- Genesis-determinism fix (PR #94) landed before 11a so nodes share a chain root
+- `NewTransactionMessage` + `NEW_TRANSACTION` already existed; the missing piece
+  was the Node handler (same start as NEW_BLOCK in Sprint 10)
+- Follow-up: the mempool request is sent on outbound connect only; the inbound
+  side does not yet pull the peer's mempool
 
 ---
 
-*Created: 2026-07-01*
+*Created: 2026-07-01 | Completed: 2026-07-02*

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ BlockSmith is a comprehensive blockchain project that goes beyond tutorials - im
 
 [![Java](https://img.shields.io/badge/Java-20+-orange.svg)](https://openjdk.org/)
 [![Maven](https://img.shields.io/badge/Maven-3.9+-blue.svg)](https://maven.apache.org/)
-[![Tests](https://img.shields.io/badge/Tests-155%20passing-brightgreen.svg)](#)
+[![Tests](https://img.shields.io/badge/Tests-166%20passing-brightgreen.svg)](#)
 [![Phase](https://img.shields.io/badge/Phase%202-In%20Progress-yellow.svg)](#)
 [![Version](https://img.shields.io/badge/Version-1.0.0-blue.svg)](#)
 
@@ -29,7 +29,7 @@ BlockSmith is a comprehensive blockchain project that goes beyond tutorials - im
 - ✅ Balance validation before transfers
 - ✅ Double-spend prevention (pending tracking)
 
-### Phase 2: Network Layer 🔄 In Progress (75%)
+### Phase 2: Network Layer ✅ Complete (100%)
 - ✅ Message protocol with JSON serialization (Sprint 8a)
 - ✅ Server-side TCP socket node (Sprint 8b)
 - ✅ Client-side peer connections with handshake (Sprint 8c)
@@ -44,7 +44,10 @@ BlockSmith is a comprehensive blockchain project that goes beyond tutorials - im
   - ✅ NEW_BLOCK broadcast, validate, and re-gossip (Sprint 10b)
   - ✅ Orphan block buffering and attachment (Sprint 10c)
   - ✅ Chain sync (GET_BLOCKS/BLOCKS) for behind nodes (Sprint 10d)
-- 🔜 Mempool synchronization (Sprint 11)
+- ✅ Mempool synchronization (Sprint 11)
+  - ✅ Transaction broadcast (NEW_TRANSACTION) + relay (Sprint 11a)
+  - ✅ Prune confirmed transactions from the mempool (Sprint 11b)
+  - ✅ Mempool sync on connect (GET_MEMPOOL/MEMPOOL) (Sprint 11c)
 
 ### Phase 3: API & Interface 🔜 Planned
 - REST API for blockchain interaction
@@ -193,7 +196,7 @@ Average attempts: ~16^difficulty (~65,536 for difficulty 4)
 mvn clean compile
 ```
 
-### Run all tests (155 tests)
+### Run all tests (166 tests)
 ```bash
 mvn test
 ```
@@ -249,7 +252,7 @@ BlockSmith/
 │   │   ├── PeerManager.java   # Peer registry with MAX_PEERS enforcement
 │   │   └── messages/           # Concrete message classes (incl. GetPeers/Peers)
 │   └── BlockSmithDemo.java     # Main demo application
-├── src/test/java/              # 155 unit tests
+├── src/test/java/              # 166 unit tests
 ├── data/                       # Blockchain persistence (JSON)
 ├── pom.xml                     # Maven configuration
 └── README.md
@@ -263,7 +266,7 @@ BlockSmith/
 |------------|-------|-------------|
 | HashUtilTest | 6 | SHA-256 hashing |
 | BlockTest | 12 | Block creation, mining, transactions |
-| BlockchainTest | 25 | Chain management, validation, balance checks |
+| BlockchainTest | 26 | Chain management, validation, balance, deterministic genesis |
 | MiningTest | 9 | Proof-of-Work mechanics |
 | TransactionTest | 22 | Transaction validation, signatures |
 | WalletTest | 13 | Key generation, addresses, signing |
@@ -280,7 +283,10 @@ BlockSmith/
 | BlockBroadcastTest | 4 | NEW_BLOCK serialization and handler |
 | OrphanBlockTest | 3 | Orphan buffering and attachment |
 | ChainSyncTest | 5 | GET_BLOCKS/BLOCKS sync handlers |
-| **Total** | **155** | All passing ✅ |
+| TransactionBroadcastTest | 4 | NEW_TRANSACTION serialization and handler |
+| MempoolPruneTest | 2 | Confirmed-tx pruning on block append |
+| MempoolSyncTest | 4 | GET_MEMPOOL/MEMPOOL sync handlers |
+| **Total** | **166** | All passing ✅ |
 
 ---
 
@@ -321,13 +327,13 @@ BlockSmith/
 | Sprint 5 | Wallets & Digital Signatures | ✅ Complete |
 | Sprint 6 | Economic System | ✅ Complete |
 
-### Phase 2: Network Layer (75% Complete)
+### Phase 2: Network Layer ✅ Complete (100%)
 | Sprint | Title | Status |
 |--------|-------|--------|
 | Sprint 8 | P2P Networking | ✅ Complete (8a, 8b, 8c, 8d) |
 | Sprint 9 | Node Discovery | ✅ Complete (9a, 9b, 9c, 9d) |
 | Sprint 10 | Block Broadcasting | ✅ Complete (10a, 10b, 10c, 10d) |
-| Sprint 11 | Mempool Sync | ⬜ Planned |
+| Sprint 11 | Mempool Sync | ✅ Complete (11a, 11b, 11c) |
 
 ### Phase 3: API & Interface
 | Sprint | Title | Status |
@@ -361,4 +367,4 @@ This project is for educational purposes.
 
 ---
 
-*Last updated: 2026-06-30 | Phase 2 Sprint 10 Complete (Block Broadcasting)*
+*Last updated: 2026-07-02 | Phase 2 Complete (Sprint 11 - Mempool Sync)*


### PR DESCRIPTION
## Summary
Marks Sprint 11 (Mempool Sync) complete and closes out Phase 2 (Network Layer), following the Sprint 10 docs pattern.

- **STATUS.md**: sprint/milestone -> 11c complete, Phase 2 75% -> 100% (+ Phase 3 as next), test summary 155 -> 166 (BlockchainTest 25->26 for the genesis test, plus 3 new Sprint 11 test classes), Node/Blockchain/messages notes, feature list, and next-session notes now point to Phase 3. Removed the deterministic-genesis item from deferred (it's fixed).
- **README.md**: tests badge/counts 155 -> 166, Phase 2 feature list + roadmap show Sprint 11 complete and Phase 2 at 100%, coverage table extended.
- **sprint11/sprint-log.md**: all three milestones (11a-11c) written up with issues/PRs and tests; outcome records Phase 2 completion.

## Test plan
- [x] Docs-only change; `mvn test` already green at 166 from PR #106