### PR TITLE
docs: Sprint 12 plan (REST API) - opens Phase 3

### DIFF
--- a/.ai/sprints/sprint12/github-issues.md
+++ b/.ai/sprints/sprint12/github-issues.md
@@ -1,0 +1,198 @@
+# Sprint 12: GitHub Issues
+
+> Copy each issue to GitHub. Actual issue numbers are assigned on creation
+> (PRs consume the same number space, so they will not be contiguous).
+
+---
+
+## Milestone 12a: HTTP server bootstrap + read/query endpoints
+
+---
+
+### Add ApiServer bootstrap + HTTP dependency
+
+**Labels:** `sprint-12`, `milestone-12a`, `enhancement`
+
+**Description:**
+
+Add the HTTP framework dependency (Javalin, pending confirmation) and an
+`ApiServer` that starts/stops on a configurable port, separate from the P2P
+port.
+
+- Add `NetworkConfig.API_PORT` (default 7070)
+- `ApiServer(Blockchain, Node, int port)` with `start()` / `stop()`
+- Wire nothing else yet - just prove the server comes up
+
+**Acceptance Criteria:**
+- [ ] Server starts and stops cleanly on the configured port
+- [ ] Holds references to the node's Blockchain and Node
+- [ ] Compiles with `mvn compile`
+
+---
+
+### Implement read/query endpoints
+
+**Labels:** `sprint-12`, `milestone-12a`, `enhancement`
+
+**Description:**
+
+- `GET /api/blocks` - full chain as JSON
+- `GET /api/blocks/{index}` - block by index (404 if out of range)
+- `GET /api/blocks/latest` - current tip
+- `GET /api/network/status` - chain length, pending count, peer count, node id
+
+**Acceptance Criteria:**
+- [ ] All four endpoints return correct JSON and status codes
+- [ ] Out-of-range block index returns 404
+- [ ] Compiles with `mvn compile`
+
+---
+
+### Unit tests for read endpoints
+
+**Labels:** `sprint-12`, `milestone-12a`, `test`
+
+**Description:**
+
+Drive the running `ApiServer` with an HTTP client (java.net.http.HttpClient)
+against a node on an ephemeral port.
+
+**Test Cases:**
+1. `getBlocks_returnsChain`
+2. `getBlockByIndex_returnsBlock` / `getBlockByIndex_404WhenMissing`
+3. `getLatest_returnsTip`
+4. `getStatus_returnsCounts`
+
+**Acceptance Criteria:**
+- [ ] Tests added and passing
+- [ ] All existing tests still passing
+- [ ] `mvn test` green
+
+---
+
+## Milestone 12b: Transaction + mining endpoints
+
+---
+
+### Implement POST /api/transactions and GET /api/transactions/{id}
+
+**Labels:** `sprint-12`, `milestone-12b`, `enhancement`
+
+**Description:**
+
+- `POST /api/transactions` - parse a JSON transaction, add via
+  `Blockchain.addTransaction`; 201 on success, 400 on rejection; broadcast via
+  `Node.broadcastTransaction`
+- `GET /api/transactions/{id}` - find a tx by id in the pending pool or in a
+  mined block; 404 if unknown
+
+**Acceptance Criteria:**
+- [ ] Valid tx accepted (201) and broadcast; invalid rejected (400)
+- [ ] Lookup finds pending and confirmed txs; 404 otherwise
+- [ ] Compiles with `mvn compile`
+
+---
+
+### Implement POST /api/mine
+
+**Labels:** `sprint-12`, `milestone-12b`, `enhancement`
+
+**Description:**
+
+`POST /api/mine` with a miner address - mine pending transactions
+(`minePendingTransactions`), broadcast the new block via `Node.broadcastBlock`,
+return the mined block.
+
+**Acceptance Criteria:**
+- [ ] Mining produces a block and returns it as JSON
+- [ ] New block is broadcast to peers
+- [ ] Compiles with `mvn compile`
+
+---
+
+### Unit tests for transaction + mining endpoints
+
+**Labels:** `sprint-12`, `milestone-12b`, `test`
+
+**Description:**
+
+**Test Cases:**
+1. `postTransaction_acceptsValid` / `postTransaction_rejectsInvalid`
+2. `getTransactionById_findsPendingAndConfirmed`
+3. `postMine_producesBlock`
+
+**Acceptance Criteria:**
+- [ ] Tests added and passing
+- [ ] `mvn test` green
+
+---
+
+## Milestone 12c: Wallet + network endpoints + error handling
+
+---
+
+### Implement wallet + network endpoints
+
+**Labels:** `sprint-12`, `milestone-12c`, `enhancement`
+
+**Description:**
+
+- `GET /api/wallet/{address}` - balance + pending outgoing
+- `POST /api/wallet/create` - generate a `Wallet`, return the address only
+  (document that a real node never returns private keys)
+- `GET /api/network/peers` - connected peers (address, nodeId, state)
+
+**Acceptance Criteria:**
+- [ ] Wallet balance and create endpoints work
+- [ ] Peers endpoint lists connected peers
+- [ ] Compiles with `mvn compile`
+
+---
+
+### Add JSON error handling
+
+**Labels:** `sprint-12`, `milestone-12c`, `enhancement`
+
+**Description:**
+
+Consistent error envelope (`{ "error": "..." }`) and status codes for bad
+input (400), not-found (404), and server errors (500).
+
+**Acceptance Criteria:**
+- [ ] Malformed/invalid requests return a JSON error + correct status
+- [ ] Unknown routes/resources return 404 JSON
+- [ ] Compiles with `mvn compile`
+
+---
+
+### Unit tests for wallet, network, and errors
+
+**Labels:** `sprint-12`, `milestone-12c`, `test`
+
+**Description:**
+
+**Test Cases:**
+1. `getWalletBalance_returnsBalance`
+2. `postWalletCreate_returnsAddress`
+3. `getPeers_returnsConnectedPeers`
+4. `badRequest_returnsJsonError`
+
+**Acceptance Criteria:**
+- [ ] Tests added and passing
+- [ ] All existing tests still passing
+- [ ] `mvn test` green
+
+---
+
+## Summary
+
+| Milestone | Issues | Tests |
+|-----------|--------|-------|
+| 12a: Bootstrap + read endpoints | 3 | 4 tests |
+| 12b: Transaction + mining | 3 | 3 tests |
+| 12c: Wallet + network + errors | 3 | 4 tests |
+| **Total** | **9 issues** | **~11 tests** |
+
+---
+
+*Created: 2026-07-02 | Sprint 12 Planning*

--- a/.ai/sprints/sprint12/sprint-log.md
+++ b/.ai/sprints/sprint12/sprint-log.md
@@ -1,0 +1,36 @@
+# Sprint 12: REST API - Log
+
+## Sprint Timeline
+
+| Event | Date |
+|-------|------|
+| **Sprint Start** | 2026-07-02 |
+| **Sprint End** | TBD |
+
+---
+
+## Milestone 12a: HTTP server bootstrap + read/query endpoints - Pending
+
+---
+
+## Milestone 12b: Transaction + mining endpoints - Pending
+
+---
+
+## Milestone 12c: Wallet + network endpoints + error handling - Pending
+
+---
+
+## Notes
+
+- First sprint of Phase 3 (API & Interface); Phase 2 completed at Sprint 11
+- Continuing issue-first, milestone-per-branch workflow from Sprints 8-11
+- **HTTP framework pending final confirmation**: Javalin (recommended, roadmap's
+  first-named option) vs built-in `com.sun.net.httpserver` (zero-dependency) vs
+  Spark. The Maven dependency + code are held until confirmed
+- The API sits beside the P2P layer and drives the same Blockchain/Node, so
+  actions taken over HTTP propagate to peers via the existing broadcast paths
+
+---
+
+*Created: 2026-07-02*

--- a/.ai/sprints/sprint12/sprint-plan.md
+++ b/.ai/sprints/sprint12/sprint-plan.md
@@ -1,0 +1,141 @@
+# Sprint 12: REST API
+
+## Sprint Info
+
+| Field | Value |
+|-------|-------|
+| **Sprint** | 12 |
+| **Title** | REST API |
+| **Phase** | Phase 3: API & Interface |
+| **Status** | Planning |
+| **Depends On** | Phase 2 Complete (Sprints 8-11) |
+
+> **Framework decision (pending final confirmation):** **Javalin** (the roadmap's
+> first-named option). Lightweight, Jetty-backed, clean routing, easy JSON via
+> Gson. Adds one Maven dependency (`io.javalin:javalin`). This can still be
+> swapped for the built-in `com.sun.net.httpserver` (zero-dependency) or Spark
+> before 12a implementation begins.
+
+---
+
+## Goal
+
+Expose the blockchain node over HTTP so it can be driven without writing Java.
+A running node serves a REST API: browse blocks, submit and look up
+transactions, trigger mining, create wallets and check balances, and inspect
+network state. This is the first step of Phase 3 and the foundation the web
+dashboard (Sprint 13) will build on.
+
+---
+
+## Milestones
+
+| Milestone | Title | Branch | Status |
+|-----------|-------|--------|--------|
+| **12a** | HTTP server bootstrap + read/query endpoints | `sprint12a/api-bootstrap` | Pending |
+| **12b** | Transaction + mining endpoints | `sprint12b/api-transactions` | Pending |
+| **12c** | Wallet + network endpoints + error handling | `sprint12c/api-wallet-network` | Pending |
+
+---
+
+## Milestone 12a: HTTP server bootstrap + read/query endpoints
+
+### Deliverables
+
+- [ ] Add the HTTP dependency and an `ApiServer` class that starts/stops on a
+      configurable port (e.g. `NetworkConfig.API_PORT`, default 7070, separate
+      from the P2P port)
+- [ ] `ApiServer` holds a reference to the node's `Blockchain` (and `Node`)
+- [ ] Read endpoints:
+  - `GET /api/blocks` - full chain
+  - `GET /api/blocks/{index}` - block by index (404 if out of range)
+  - `GET /api/blocks/latest` - current tip
+  - `GET /api/network/status` - chain length, pending count, peer count, node id
+- [ ] JSON responses via Gson
+- [ ] Tests: server starts; each endpoint returns the expected JSON / status code
+
+### Why this is first
+
+The server bootstrap + read endpoints are the foundation: they prove the HTTP
+layer works end-to-end against the existing `Blockchain` before any state-
+changing endpoints are added.
+
+---
+
+## Milestone 12b: Transaction + mining endpoints
+
+### Deliverables
+
+- [ ] `POST /api/transactions` - accept a JSON transaction, validate + add via
+      `Blockchain.addTransaction`; 201 on success, 400 on rejection. Broadcast
+      it to peers via `Node.broadcastTransaction`
+- [ ] `GET /api/transactions/{id}` - look up a transaction by id in the pending
+      pool and in mined blocks; 404 if unknown
+- [ ] `POST /api/mine` - mine pending transactions to a miner address
+      (`minePendingTransactions`), broadcast the new block via
+      `Node.broadcastBlock`; return the mined block
+- [ ] Tests: submit tx (accepted/rejected), look up tx, mine produces a block
+
+### Notes
+
+- Reuses existing validation and the Sprint 10/11 broadcast paths, so API
+  submissions propagate across the network exactly like gossiped ones.
+
+---
+
+## Milestone 12c: Wallet + network endpoints + error handling
+
+### Deliverables
+
+- [ ] `GET /api/wallet/{address}` - balance + pending outgoing for an address
+- [ ] `POST /api/wallet/create` - generate a new `Wallet`, return address
+      (never return the private key in a real system - note this in THEORY
+      comment; for the educational demo, document the choice explicitly)
+- [ ] `GET /api/network/peers` - connected peers (address, nodeId, state)
+- [ ] Consistent JSON error envelope (`{ "error": "..." }`) + status codes for
+      bad input, not-found, and server errors
+- [ ] Tests: wallet balance, wallet create, peers list, error responses
+
+---
+
+## Theory: Why a REST API on top of a P2P node
+
+```
+A blockchain node has two very different audiences:
+
+1. OTHER NODES  -> talk the P2P gossip protocol (TCP, our Message types)
+2. USERS/TOOLS  -> talk HTTP/JSON (browsers, curl, the Sprint 13 dashboard)
+
+The REST API is the SECOND interface. It does NOT replace the P2P layer - it
+sits beside it and drives the SAME Blockchain/Node:
+
+  submit tx   -> POST /api/transactions -> addTransaction -> broadcast to peers
+  mine        -> POST /api/mine         -> minePendingTransactions -> broadcast
+  read chain  -> GET  /api/blocks       -> blockchain.getChain()
+
+So an action taken over HTTP on one node propagates through the P2P network to
+every other node - the API is just a human-friendly front door.
+```
+
+---
+
+## Dependencies
+
+- Phase 2 complete: `Blockchain`, `Node` (broadcastTransaction / broadcastBlock),
+  `Wallet`, `Transaction`, `PeerManager`
+- Gson (already a dependency) for JSON
+- HTTP framework: Javalin (pending confirmation)
+
+---
+
+## Open decisions
+
+- **HTTP framework**: Javalin (recommended) vs built-in `HttpServer` (zero-dep)
+  vs Spark - confirm before 12a
+- **API port**: default 7070 (distinct from P2P `DEFAULT_PORT`)
+- **Wallet key handling**: educational demo returns address only; document that
+  a real node never exposes private keys over the API
+
+---
+
+*Created: 2026-07-02 | Sprint 12 Planning*


### PR DESCRIPTION
## Summary
Plans Sprint 12 (REST API), the first sprint of Phase 3 (API & Interface), following the Sprint 10/11 planning format.

- **sprint-plan.md**: goal, three milestones (12a bootstrap + read endpoints, 12b transaction + mining, 12c wallet + network + errors), per-milestone deliverables, theory on why a REST API sits beside the P2P layer, dependencies, open decisions.
- **github-issues.md**: copy-ready text for all 9 issues.
- **sprint-log.md**: milestone skeleton.

## Pending decision (flagged, not yet locked)
HTTP framework: **Javalin** (recommended, the roadmap's first-named option) vs built-in `com.sun.net.httpserver` (zero-dependency, fits the from-scratch ethos) vs Spark. The plan assumes Javalin but the **Maven dependency + code are held until confirmed** - only the reversible planning + issues are being created now.

## Test plan
- [x] Docs-only change