### PR TITLE
Sprint 12a: REST API bootstrap + read endpoints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.1</junit.version>
         <gson.version>2.10.1</gson.version>
+        <javalin.version>6.3.0</javalin.version>
     </properties>
 
     <dependencies>
@@ -27,6 +28,13 @@
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>${gson.version}</version>
+        </dependency>
+
+        <!-- REST API (embedded Jetty) -->
+        <dependency>
+            <groupId>io.javalin</groupId>
+            <artifactId>javalin</artifactId>
+            <version>${javalin.version}</version>
         </dependency>
 
         <!-- Testing -->

--- a/src/main/java/com/blocksmith/api/ApiServer.java
+++ b/src/main/java/com/blocksmith/api/ApiServer.java
@@ -1,0 +1,120 @@
+package com.blocksmith.api;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.blocksmith.core.Blockchain;
+import com.blocksmith.network.NetworkConfig;
+import com.blocksmith.network.Node;
+import com.google.gson.Gson;
+
+import io.javalin.Javalin;
+import io.javalin.http.Context;
+
+/**
+ * THEORY: REST API in front of a P2P node.
+ *
+ * A blockchain node has two audiences: OTHER NODES (which speak our TCP gossip
+ * protocol) and USERS/TOOLS (which speak HTTP/JSON). This class is the second
+ * interface. It does not replace the P2P layer - it sits beside it and drives
+ * the SAME {@link Blockchain}/{@link Node}, so an action taken over HTTP on one
+ * node propagates to peers through the existing broadcast paths.
+ *
+ * Milestone 12a provides the server bootstrap and read-only endpoints;
+ * state-changing endpoints (transactions, mining, wallets) follow in 12b/12c.
+ *
+ * JSON is produced with Gson (already a project dependency) rather than
+ * Javalin's default mapper, so responses match the wire format used elsewhere.
+ */
+public class ApiServer {
+
+    private final Node node;
+    private final Blockchain blockchain;
+    private final int port;
+    private final Gson gson = new Gson();
+
+    private Javalin app;
+
+    public ApiServer(Node node) {
+        this(node, NetworkConfig.API_PORT);
+    }
+
+    public ApiServer(Node node, int port) {
+        this.node = node;
+        this.blockchain = node.getBlockchain();
+        this.port = port;
+    }
+
+    /** Starts the HTTP server and registers routes. */
+    public void start() {
+        app = Javalin.create(config -> config.showJavalinBanner = false);
+        registerRoutes();
+        app.start(port);
+    }
+
+    /** Stops the HTTP server if it is running. */
+    public void stop() {
+        if (app != null) {
+            app.stop();
+            app = null;
+        }
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    // ===== ROUTES =====
+
+    private void registerRoutes() {
+        // Read/query endpoints (Milestone 12a).
+        app.get("/api/blocks", ctx -> json(ctx, blockchain.getChain()));
+        app.get("/api/blocks/latest", ctx -> json(ctx, blockchain.getLatestBlock()));
+        app.get("/api/blocks/{index}", this::getBlockByIndex);
+        app.get("/api/network/status", ctx -> json(ctx, status()));
+    }
+
+    private void getBlockByIndex(Context ctx) {
+        int index;
+        try {
+            index = Integer.parseInt(ctx.pathParam("index"));
+        } catch (NumberFormatException e) {
+            ctx.status(400);
+            json(ctx, error("Block index must be an integer"));
+            return;
+        }
+
+        if (index < 0 || index >= blockchain.getChainSize()) {
+            ctx.status(404);
+            json(ctx, error("No block at index " + index));
+            return;
+        }
+        json(ctx, blockchain.getBlock(index));
+    }
+
+    // ===== HELPERS =====
+
+    /** A snapshot of node/chain state for GET /api/network/status. */
+    private Map<String, Object> status() {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("nodeId", node.getNodeId());
+        m.put("p2pPort", node.getPort());
+        m.put("apiPort", port);
+        m.put("chainLength", blockchain.getChainSize());
+        m.put("pendingTransactions", blockchain.getPendingTransactions().size());
+        m.put("connectedPeers", node.getPeerManager().getConnectedPeers().size());
+        return m;
+    }
+
+    private Map<String, String> error(String message) {
+        Map<String, String> m = new LinkedHashMap<>();
+        m.put("error", message);
+        return m;
+    }
+
+    /** Writes {@code data} as a JSON response using Gson. */
+    private void json(Context ctx, Object data) {
+        ctx.contentType("application/json");
+        ctx.result(gson.toJson(data));
+    }
+}

--- a/src/main/java/com/blocksmith/network/NetworkConfig.java
+++ b/src/main/java/com/blocksmith/network/NetworkConfig.java
@@ -25,7 +25,14 @@ public class NetworkConfig {
      * Bitcoin uses 8333, we use 8335 to avoid conflicts.
      */
     public static final int DEFAULT_PORT = 8335;
-    
+
+    /**
+     * Default port for the REST API (HTTP).
+     * Kept separate from the P2P port so a node can serve peers and users at
+     * the same time.
+     */
+    public static final int API_PORT = 7070;
+
     /**
      * Maximum number of peer connections.
      * Keeps resource usage manageable for educational purposes.

--- a/src/test/java/com/blocksmith/api/ApiReadEndpointsTest.java
+++ b/src/test/java/com/blocksmith/api/ApiReadEndpointsTest.java
@@ -1,0 +1,127 @@
+package com.blocksmith.api;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.blocksmith.network.Node;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the Milestone 12a read/query endpoints. The ApiServer is started on
+ * a real port and driven with an HTTP client, exercising the full Javalin ->
+ * Blockchain path.
+ */
+@DisplayName("API Read Endpoint Tests")
+class ApiReadEndpointsTest {
+
+    private static final int API_PORT_BASE = 17070;
+    private static final int P2P_PORT_BASE = 18500;
+    private static int counter = 0;
+
+    private Node node;
+    private ApiServer api;
+    private int apiPort;
+    private final HttpClient client = HttpClient.newHttpClient();
+
+    @BeforeEach
+    void setUp() {
+        int offset = counter++;
+        apiPort = API_PORT_BASE + offset;
+        // Node is never started (no TCP server needed); the API only reads it.
+        node = new Node(P2P_PORT_BASE + offset);
+        api = new ApiServer(node, apiPort);
+        api.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (api != null) api.stop();
+        if (node != null) node.stop();
+    }
+
+    private HttpResponse<String> get(String path) throws Exception {
+        return client.send(
+                HttpRequest.newBuilder()
+                        .uri(URI.create("http://localhost:" + apiPort + path))
+                        .GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    @Test
+    @DisplayName("GET /api/blocks returns the whole chain")
+    void getBlocks_returnsChain() throws Exception {
+        node.getBlockchain().addBlock("first");
+        node.getBlockchain().addBlock("second");
+        int expected = node.getBlockchain().getChainSize(); // genesis + 2 = 3
+
+        HttpResponse<String> res = get("/api/blocks");
+
+        assertEquals(200, res.statusCode(), "Should return 200");
+        JsonArray blocks = JsonParser.parseString(res.body()).getAsJsonArray();
+        assertEquals(expected, blocks.size(), "Should return every block in the chain");
+    }
+
+    @Test
+    @DisplayName("GET /api/blocks/{index} returns the block at that index")
+    void getBlockByIndex_returnsBlock() throws Exception {
+        node.getBlockchain().addBlock("first");
+
+        HttpResponse<String> res = get("/api/blocks/1");
+
+        assertEquals(200, res.statusCode(), "Should return 200");
+        JsonObject block = JsonParser.parseString(res.body()).getAsJsonObject();
+        assertEquals(1, block.get("index").getAsInt(), "Should return block #1");
+    }
+
+    @Test
+    @DisplayName("GET /api/blocks/{index} returns 404 for an out-of-range index")
+    void getBlockByIndex_404WhenMissing() throws Exception {
+        HttpResponse<String> res = get("/api/blocks/99");
+
+        assertEquals(404, res.statusCode(), "Missing block should return 404");
+        JsonObject body = JsonParser.parseString(res.body()).getAsJsonObject();
+        assertTrue(body.has("error"), "404 body should carry an error message");
+    }
+
+    @Test
+    @DisplayName("GET /api/blocks/latest returns the current tip")
+    void getLatest_returnsTip() throws Exception {
+        node.getBlockchain().addBlock("first");
+        String tipHash = node.getBlockchain().getLatestBlock().getHash();
+
+        HttpResponse<String> res = get("/api/blocks/latest");
+
+        assertEquals(200, res.statusCode(), "Should return 200");
+        JsonObject block = JsonParser.parseString(res.body()).getAsJsonObject();
+        assertEquals(tipHash, block.get("hash").getAsString(), "Should return the tip block");
+    }
+
+    @Test
+    @DisplayName("GET /api/network/status reports chain and node counts")
+    void getStatus_returnsCounts() throws Exception {
+        node.getBlockchain().addBlock("first");
+        int chainLength = node.getBlockchain().getChainSize();
+
+        HttpResponse<String> res = get("/api/network/status");
+
+        assertEquals(200, res.statusCode(), "Should return 200");
+        JsonObject status = JsonParser.parseString(res.body()).getAsJsonObject();
+        assertEquals(chainLength, status.get("chainLength").getAsInt(),
+                "Status should report the real chain length");
+        assertEquals(0, status.get("connectedPeers").getAsInt(),
+                "A lone node has no connected peers");
+        assertEquals(node.getNodeId(), status.get("nodeId").getAsString(),
+                "Status should report the node id");
+    }
+}


### PR DESCRIPTION
## Summary
First milestone of Sprint 12 (Phase 3). Adds an HTTP layer beside the P2P node so the blockchain can be queried over REST.

- Add **Javalin** (`io.javalin:javalin` 6.3.0, embedded Jetty) as the HTTP framework.
- `NetworkConfig.API_PORT` (default 7070), separate from the P2P port.
- `ApiServer(Node[, port])` with `start()` / `stop()`; JSON produced via Gson (matches the existing wire format, avoids pulling Javalin's default mapper).
- Read/query endpoints:
  - `GET /api/blocks` - full chain
  - `GET /api/blocks/{index}` - block by index (400 non-integer, 404 out of range)
  - `GET /api/blocks/latest` - current tip
  - `GET /api/network/status` - chain length, pending count, peer count, node id
- 5 new tests (`ApiReadEndpointsTest`) drive the running server with `java.net.http.HttpClient`.

## Notes
- The API drives the same `Blockchain`/`Node`, so state-changing endpoints in 12b/12c will propagate to peers through the existing broadcast paths.

## Test plan
- [x] `mvn test` green - 171 tests passing
- [x] `mvn compile` clean

Closes #110
Closes #111
Closes #112