### PR TITLE
Sprint 12b: transaction + mining API endpoints

### DIFF
--- a/src/main/java/com/blocksmith/api/ApiServer.java
+++ b/src/main/java/com/blocksmith/api/ApiServer.java
@@ -3,10 +3,15 @@ package com.blocksmith.api;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import com.blocksmith.core.Block;
 import com.blocksmith.core.Blockchain;
+import com.blocksmith.core.Transaction;
 import com.blocksmith.network.NetworkConfig;
 import com.blocksmith.network.Node;
 import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
 
 import io.javalin.Javalin;
 import io.javalin.http.Context;
@@ -72,6 +77,95 @@ public class ApiServer {
         app.get("/api/blocks/latest", ctx -> json(ctx, blockchain.getLatestBlock()));
         app.get("/api/blocks/{index}", this::getBlockByIndex);
         app.get("/api/network/status", ctx -> json(ctx, status()));
+
+        // Transaction + mining endpoints (Milestone 12b).
+        app.post("/api/transactions", this::postTransaction);
+        app.get("/api/transactions/{id}", this::getTransactionById);
+        app.post("/api/mine", this::postMine);
+    }
+
+    // ===== 12b: TRANSACTION + MINING =====
+
+    /** Accepts a transaction, adds it to the mempool, and broadcasts it. */
+    private void postTransaction(Context ctx) {
+        JsonObject body;
+        try {
+            body = JsonParser.parseString(ctx.body()).getAsJsonObject();
+        } catch (JsonSyntaxException | IllegalStateException e) {
+            ctx.status(400);
+            json(ctx, error("Request body must be a JSON object"));
+            return;
+        }
+
+        if (!body.has("sender") || !body.has("recipient") || !body.has("amount")) {
+            ctx.status(400);
+            json(ctx, error("Transaction requires sender, recipient, and amount"));
+            return;
+        }
+
+        // Build the transaction through its constructor so the id and timestamp
+        // are computed correctly (Gson would bypass the constructor).
+        Transaction tx = new Transaction(
+                body.get("sender").getAsString(),
+                body.get("recipient").getAsString(),
+                body.get("amount").getAsDouble());
+
+        if (!blockchain.addTransaction(tx)) {
+            ctx.status(400);
+            json(ctx, error("Transaction rejected (invalid or insufficient funds)"));
+            return;
+        }
+
+        node.broadcastTransaction(tx);
+        ctx.status(201);
+        json(ctx, tx);
+    }
+
+    /** Looks up a transaction by id in the mempool or in a mined block. */
+    private void getTransactionById(Context ctx) {
+        String id = ctx.pathParam("id");
+        Transaction found = findTransaction(id);
+        if (found == null) {
+            ctx.status(404);
+            json(ctx, error("No transaction with id " + id));
+            return;
+        }
+        json(ctx, found);
+    }
+
+    /** Mines the pending transactions to a miner address and broadcasts the block. */
+    private void postMine(Context ctx) {
+        JsonObject body;
+        try {
+            body = JsonParser.parseString(ctx.body()).getAsJsonObject();
+        } catch (JsonSyntaxException | IllegalStateException e) {
+            ctx.status(400);
+            json(ctx, error("Request body must be a JSON object"));
+            return;
+        }
+
+        if (!body.has("minerAddress") || body.get("minerAddress").getAsString().isBlank()) {
+            ctx.status(400);
+            json(ctx, error("minerAddress is required"));
+            return;
+        }
+
+        Block mined = blockchain.minePendingTransactions(body.get("minerAddress").getAsString());
+        node.broadcastBlock(mined);
+        ctx.status(201);
+        json(ctx, mined);
+    }
+
+    private Transaction findTransaction(String id) {
+        for (Transaction tx : blockchain.getPendingTransactions()) {
+            if (id.equals(tx.getTransactionId())) return tx;
+        }
+        for (Block block : blockchain.getChain()) {
+            for (Transaction tx : block.getTransactions()) {
+                if (id.equals(tx.getTransactionId())) return tx;
+            }
+        }
+        return null;
     }
 
     private void getBlockByIndex(Context ctx) {

--- a/src/test/java/com/blocksmith/api/ApiTransactionEndpointsTest.java
+++ b/src/test/java/com/blocksmith/api/ApiTransactionEndpointsTest.java
@@ -1,0 +1,141 @@
+package com.blocksmith.api;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.blocksmith.network.Node;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the Milestone 12b transaction + mining endpoints, driving the
+ * running ApiServer over HTTP.
+ */
+@DisplayName("API Transaction Endpoint Tests")
+class ApiTransactionEndpointsTest {
+
+    private static final int API_PORT_BASE = 17100;
+    private static final int P2P_PORT_BASE = 18600;
+    private static int counter = 0;
+
+    private Node node;
+    private ApiServer api;
+    private int apiPort;
+    private final HttpClient client = HttpClient.newHttpClient();
+
+    @BeforeEach
+    void setUp() {
+        int offset = counter++;
+        apiPort = API_PORT_BASE + offset;
+        node = new Node(P2P_PORT_BASE + offset);
+        api = new ApiServer(node, apiPort);
+        api.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (api != null) api.stop();
+        if (node != null) node.stop();
+    }
+
+    private HttpResponse<String> get(String path) throws Exception {
+        return client.send(
+                HttpRequest.newBuilder()
+                        .uri(URI.create("http://localhost:" + apiPort + path))
+                        .GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    private HttpResponse<String> post(String path, String body) throws Exception {
+        return client.send(
+                HttpRequest.newBuilder()
+                        .uri(URI.create("http://localhost:" + apiPort + path))
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString(body))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    /** Gives "Miner1" a spendable balance by mining a reward block. */
+    private void fundMiner1() {
+        node.getBlockchain().minePendingTransactions("Miner1");
+    }
+
+    @Test
+    @DisplayName("POST /api/transactions accepts a valid transaction")
+    void postTransaction_acceptsValid() throws Exception {
+        fundMiner1();
+
+        HttpResponse<String> res = post("/api/transactions",
+                "{\"sender\":\"Miner1\",\"recipient\":\"Alice\",\"amount\":30}");
+
+        assertEquals(201, res.statusCode(), "Valid transaction should be accepted");
+        JsonObject tx = JsonParser.parseString(res.body()).getAsJsonObject();
+        assertTrue(tx.has("transactionId"), "Response should include the assigned id");
+        assertEquals(1, node.getBlockchain().getPendingTransactions().size(),
+                "Transaction should be in the mempool");
+    }
+
+    @Test
+    @DisplayName("POST /api/transactions rejects a transaction with insufficient funds")
+    void postTransaction_rejectsInvalid() throws Exception {
+        HttpResponse<String> res = post("/api/transactions",
+                "{\"sender\":\"Nobody\",\"recipient\":\"Alice\",\"amount\":100}");
+
+        assertEquals(400, res.statusCode(), "Unfunded transaction should be rejected");
+        assertEquals(0, node.getBlockchain().getPendingTransactions().size(),
+                "Rejected transaction must not enter the mempool");
+    }
+
+    @Test
+    @DisplayName("GET /api/transactions/{id} finds pending and confirmed transactions")
+    void getTransactionById_findsPendingAndConfirmed() throws Exception {
+        fundMiner1();
+        HttpResponse<String> submit = post("/api/transactions",
+                "{\"sender\":\"Miner1\",\"recipient\":\"Alice\",\"amount\":30}");
+        String id = JsonParser.parseString(submit.body()).getAsJsonObject()
+                .get("transactionId").getAsString();
+
+        // While still pending.
+        HttpResponse<String> pending = get("/api/transactions/" + id);
+        assertEquals(200, pending.statusCode(), "Pending transaction should be found");
+
+        // After a block confirms it.
+        post("/api/mine", "{\"minerAddress\":\"Miner2\"}");
+        HttpResponse<String> confirmed = get("/api/transactions/" + id);
+        assertEquals(200, confirmed.statusCode(), "Confirmed transaction should still be found");
+        assertEquals(id, JsonParser.parseString(confirmed.body()).getAsJsonObject()
+                .get("transactionId").getAsString(), "Should return the same transaction");
+    }
+
+    @Test
+    @DisplayName("GET /api/transactions/{id} returns 404 for an unknown id")
+    void getTransactionById_404WhenUnknown() throws Exception {
+        HttpResponse<String> res = get("/api/transactions/does-not-exist");
+
+        assertEquals(404, res.statusCode(), "Unknown transaction id should return 404");
+    }
+
+    @Test
+    @DisplayName("POST /api/mine produces a new block")
+    void postMine_producesBlock() throws Exception {
+        int before = node.getBlockchain().getChainSize();
+
+        HttpResponse<String> res = post("/api/mine", "{\"minerAddress\":\"Miner1\"}");
+
+        assertEquals(201, res.statusCode(), "Mining should succeed");
+        JsonObject block = JsonParser.parseString(res.body()).getAsJsonObject();
+        assertEquals(before, block.get("index").getAsInt(), "Mined block extends the tip");
+        assertEquals(before + 1, node.getBlockchain().getChainSize(),
+                "Chain should grow by one block");
+    }
+}


### PR DESCRIPTION
## Summary
Makes the REST API write-capable. Transactions and blocks created over HTTP now flow into the same Blockchain/Node and propagate to peers via the Sprint 10/11 broadcast paths.

- `POST /api/transactions` - builds a `Transaction` through its constructor (so id/timestamp are computed, not taken from the body), adds via `addTransaction`; 201 + broadcast on success, 400 on rejection (invalid / insufficient funds / missing fields / malformed JSON).
- `GET /api/transactions/{id}` - finds a tx in the mempool or in any mined block; 404 otherwise.
- `POST /api/mine` - `minePendingTransactions(minerAddress)`, broadcasts the block, returns it; 400 if minerAddress missing.
- 5 new tests (`ApiTransactionEndpointsTest`): accept/reject submit, lookup pending+confirmed, 404 unknown, mine produces a block.

## Design note
Request bodies are parsed field-by-field rather than Gson-deserialized straight into `Transaction`, because Gson bypasses the constructor and would leave the final `transactionId`/`timestamp` unset.

## Test plan
- [x] `mvn test` green - 176 tests passing
- [x] `mvn compile` clean

Closes #114
Closes #115
Closes #116