### PR TITLE
Sprint 12c: wallet + network API endpoints + error handling

### DIFF
--- a/src/main/java/com/blocksmith/api/ApiServer.java
+++ b/src/main/java/com/blocksmith/api/ApiServer.java
@@ -1,13 +1,17 @@
 package com.blocksmith.api;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import com.blocksmith.core.Block;
 import com.blocksmith.core.Blockchain;
 import com.blocksmith.core.Transaction;
+import com.blocksmith.core.Wallet;
 import com.blocksmith.network.NetworkConfig;
 import com.blocksmith.network.Node;
+import com.blocksmith.network.PeerInfo;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
@@ -82,6 +86,25 @@ public class ApiServer {
         app.post("/api/transactions", this::postTransaction);
         app.get("/api/transactions/{id}", this::getTransactionById);
         app.post("/api/mine", this::postMine);
+
+        // Wallet + network endpoints (Milestone 12c).
+        app.get("/api/wallet/{address}", this::getWallet);
+        app.post("/api/wallet/create", this::postWalletCreate);
+        app.get("/api/network/peers", this::getPeers);
+
+        // JSON error handling (Milestone 12c).
+        app.exception(Exception.class, (e, ctx) -> {
+            ctx.status(500);
+            json(ctx, error("Internal server error"));
+        });
+        app.error(404, ctx -> {
+            // Leave explicit JSON 404s (from our handlers) untouched; only
+            // replace the framework default for unmatched routes.
+            String contentType = ctx.res().getContentType();
+            if (contentType == null || !contentType.contains("application/json")) {
+                json(ctx, error("Not found: " + ctx.path()));
+            }
+        });
     }
 
     // ===== 12b: TRANSACTION + MINING =====
@@ -166,6 +189,53 @@ public class ApiServer {
             }
         }
         return null;
+    }
+
+    // ===== 12c: WALLET + NETWORK =====
+
+    /** Reports an address's confirmed balance and its pending outgoing total. */
+    private void getWallet(Context ctx) {
+        String address = ctx.pathParam("address");
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("address", address);
+        m.put("balance", blockchain.getBalance(address));
+        m.put("pendingOutgoing", pendingOutgoing(address));
+        json(ctx, m);
+    }
+
+    /**
+     * Creates a fresh wallet and returns its address ONLY. A real node must
+     * never expose the private key over the API - the key stays with the owner;
+     * here we simply never serialize it.
+     */
+    private void postWalletCreate(Context ctx) {
+        Wallet wallet = new Wallet();
+        Map<String, String> m = new LinkedHashMap<>();
+        m.put("address", wallet.getAddress());
+        ctx.status(201);
+        json(ctx, m);
+    }
+
+    /** Lists the currently connected peers. */
+    private void getPeers(Context ctx) {
+        List<Map<String, Object>> peers = new ArrayList<>();
+        for (PeerInfo peer : node.getPeerManager().getConnectedPeers()) {
+            Map<String, Object> m = new LinkedHashMap<>();
+            m.put("address", peer.getAddress());
+            m.put("nodeId", peer.getNodeId());
+            m.put("state", peer.getState().toString());
+            peers.add(m);
+        }
+        json(ctx, peers);
+    }
+
+    /** Sum of pending transactions sent by {@code address}. */
+    private double pendingOutgoing(String address) {
+        double sum = 0;
+        for (Transaction tx : blockchain.getPendingTransactions()) {
+            if (address.equals(tx.getSender())) sum += tx.getAmount();
+        }
+        return sum;
     }
 
     private void getBlockByIndex(Context ctx) {

--- a/src/test/java/com/blocksmith/api/ApiWalletNetworkEndpointsTest.java
+++ b/src/test/java/com/blocksmith/api/ApiWalletNetworkEndpointsTest.java
@@ -1,0 +1,116 @@
+package com.blocksmith.api;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.blocksmith.network.Node;
+import com.blocksmith.util.BlockchainConfig;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the Milestone 12c wallet + network endpoints and JSON error
+ * handling, driving the running ApiServer over HTTP.
+ */
+@DisplayName("API Wallet & Network Endpoint Tests")
+class ApiWalletNetworkEndpointsTest {
+
+    private static final int API_PORT_BASE = 17200;
+    private static final int P2P_PORT_BASE = 18700;
+    private static int counter = 0;
+
+    private Node node;
+    private ApiServer api;
+    private int apiPort;
+    private final HttpClient client = HttpClient.newHttpClient();
+
+    @BeforeEach
+    void setUp() {
+        int offset = counter++;
+        apiPort = API_PORT_BASE + offset;
+        node = new Node(P2P_PORT_BASE + offset);
+        api = new ApiServer(node, apiPort);
+        api.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (api != null) api.stop();
+        if (node != null) node.stop();
+    }
+
+    private HttpResponse<String> get(String path) throws Exception {
+        return client.send(
+                HttpRequest.newBuilder()
+                        .uri(URI.create("http://localhost:" + apiPort + path))
+                        .GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    private HttpResponse<String> post(String path) throws Exception {
+        return client.send(
+                HttpRequest.newBuilder()
+                        .uri(URI.create("http://localhost:" + apiPort + path))
+                        .POST(HttpRequest.BodyPublishers.noBody())
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    @Test
+    @DisplayName("GET /api/wallet/{address} returns the address balance")
+    void getWalletBalance_returnsBalance() throws Exception {
+        node.getBlockchain().minePendingTransactions("Miner1"); // reward = 50
+
+        HttpResponse<String> res = get("/api/wallet/Miner1");
+
+        assertEquals(200, res.statusCode(), "Should return 200");
+        JsonObject wallet = JsonParser.parseString(res.body()).getAsJsonObject();
+        assertEquals(BlockchainConfig.MINING_REWARD, wallet.get("balance").getAsDouble(), 0.001,
+                "Balance should equal the mining reward");
+        assertEquals(0.0, wallet.get("pendingOutgoing").getAsDouble(), 0.001,
+                "No pending outgoing yet");
+    }
+
+    @Test
+    @DisplayName("POST /api/wallet/create returns a new address")
+    void postWalletCreate_returnsAddress() throws Exception {
+        HttpResponse<String> res = post("/api/wallet/create");
+
+        assertEquals(201, res.statusCode(), "Should return 201");
+        JsonObject body = JsonParser.parseString(res.body()).getAsJsonObject();
+        assertTrue(body.has("address"), "Response should include an address");
+        assertTrue(body.get("address").getAsString().startsWith("0x"),
+                "Address should be 0x-prefixed");
+        assertFalse(body.has("privateKey"), "Private key must never be returned");
+    }
+
+    @Test
+    @DisplayName("GET /api/network/peers returns connected peers (empty for a lone node)")
+    void getPeers_returnsConnectedPeers() throws Exception {
+        HttpResponse<String> res = get("/api/network/peers");
+
+        assertEquals(200, res.statusCode(), "Should return 200");
+        JsonArray peers = JsonParser.parseString(res.body()).getAsJsonArray();
+        assertEquals(0, peers.size(), "A lone node has no connected peers");
+    }
+
+    @Test
+    @DisplayName("Unknown routes return a JSON error with 404")
+    void unknownRoute_returnsJsonError() throws Exception {
+        HttpResponse<String> res = get("/api/does-not-exist");
+
+        assertEquals(404, res.statusCode(), "Unknown route should return 404");
+        JsonObject body = JsonParser.parseString(res.body()).getAsJsonObject();
+        assertTrue(body.has("error"), "404 body should be a JSON error envelope");
+    }
+}


### PR DESCRIPTION
## Summary
Final milestone of Sprint 12. Completes the REST surface with wallet and network endpoints and a consistent JSON error envelope.

- `GET /api/wallet/{address}` - confirmed balance + pending outgoing (pending computed by scanning the mempool, so no change to `Blockchain` visibility).
- `POST /api/wallet/create` - generates a `Wallet`, returns the **address only** (documents that a real node never exposes the private key).
- `GET /api/network/peers` - connected peers (address, nodeId, state).
- JSON error handling: uncaught exceptions -> 500 `{"error":...}`; unmatched routes -> 404 `{"error":...}`. Explicit JSON 404s from handlers are preserved (the 404 mapper only replaces non-JSON framework defaults).
- 4 new tests (`ApiWalletNetworkEndpointsTest`): balance, wallet create (asserts no private key leaks), peers list, unknown-route JSON 404.

## Test plan
- [x] `mvn test` green - 180 tests passing
- [x] `mvn compile` clean

Closes #118
Closes #119
Closes #120