### PR TITLE
docs: Sprint 12 complete (REST API) - Phase 3 in progress

### DIFF
--- a/.ai/ONBOARDING.md
+++ b/.ai/ONBOARDING.md
@@ -38,10 +38,10 @@
 | **Build Tool** | Maven 3.9.x |
 | **Test Framework** | JUnit 5 |
 | **Serialization** | Gson 2.10.1 |
-| **Current Phase** | Phase 2: Network Layer — Complete |
-| **Current Sprint** | Sprint 11 (Mempool Sync) — Complete |
-| **Current Milestone** | 11c Complete; next: Phase 3 (API & Interface) |
-| **Total Tests** | 166 (all passing) |
+| **Current Phase** | Phase 3: API & Interface — In Progress |
+| **Current Sprint** | Sprint 12 (REST API) — Complete |
+| **Current Milestone** | 12c Complete; next: Sprint 13 (Web Dashboard) |
+| **Total Tests** | 180 (all passing) |
 | **Main Branch** | `master` |
 
 ---
@@ -112,8 +112,11 @@ BlockSmith/
 │           ├── GetMempoolMessage.java # ✅ Complete (Sprint 11c)
 │           └── MempoolMessage.java   # ✅ Complete (Sprint 11c)
 │
-├── src/test/java/com/blocksmith/     # 166 unit tests
-├── pom.xml                           # Maven configuration
+│   └── api/                          # REST API (Sprint 12)
+│       └── ApiServer.java            # ✅ Complete (Javalin: blocks, tx, mine, wallet, network)
+│
+├── src/test/java/com/blocksmith/     # 180 unit tests
+├── pom.xml                           # Maven configuration (Gson, JUnit, Javalin)
 └── README.md                         # Public documentation
 ```
 
@@ -140,12 +143,16 @@ BlockSmith/
 
 **Sprint 11: Mempool Sync** — NEW_TRANSACTION broadcast/relay + mempool dedupe, prune confirmed transactions on append, GET_MEMPOOL/MEMPOOL sync with request-on-connect.
 
+### Phase 3: API & Interface 🔄 In Progress (Sprint 12+)
+
+**Sprint 12: REST API** — Javalin `ApiServer` on port 7070: block read endpoints + network status, transaction submit/lookup + mining (broadcast on write), wallet balance/create + peers, JSON error envelope (400/404/500).
+
 ---
 
 ## What's NOT Implemented Yet
 
-### Phase 3: API & Interface (Sprints 12-15) ← NEXT
-- REST API, web dashboard, basic smart contracts, multi-sig wallets
+### Phase 3 remaining (Sprints 13-15) ← NEXT
+- Web dashboard (Sprint 13), basic smart contracts (Sprint 14), multi-sig wallets (Sprint 15)
 
 ### Phase 4: Production Features (Sprints 16-19)
 - Database persistence, dynamic difficulty, block limits, fee market
@@ -230,7 +237,10 @@ mvn compile -q; java -cp target/classes com.blocksmith.BlockSmithDemo
 | TransactionBroadcastTest | 4 | NEW_TRANSACTION serialization and handler (Sprint 11a) |
 | MempoolPruneTest | 2 | Confirmed-tx pruning on block append (Sprint 11b) |
 | MempoolSyncTest | 4 | GET_MEMPOOL/MEMPOOL sync handlers (Sprint 11c) |
-| **Total** | **166** | All passing ✅ |
+| ApiReadEndpointsTest | 5 | REST block/status read endpoints (Sprint 12a) |
+| ApiTransactionEndpointsTest | 5 | REST transaction submit/lookup + mining (Sprint 12b) |
+| ApiWalletNetworkEndpointsTest | 4 | REST wallet/network endpoints + JSON errors (Sprint 12c) |
+| **Total** | **180** | All passing ✅ |
 
 ---
 
@@ -241,7 +251,7 @@ mvn compile -q; java -cp target/classes com.blocksmith.BlockSmithDemo
 - **Doc branches**: `docs/{description}` (e.g., `docs/sprint11-complete`)
 - **Commits**: One per issue, format: `feat(scope): description #NN` — never add `Co-Authored-By`
 - **PRs**: created with `gh`, include `Closes #NN` lines, ff-only merge to sync local master
-- **Latest**: Sprint 11 complete (PR #106); docs at PR #107
+- **Latest**: Sprint 12 complete (REST API, PR #121); Phase 3 in progress
 
 ---
 
@@ -253,9 +263,9 @@ mvn compile -q; java -cp target/classes com.blocksmith.BlockSmithDemo
 | `CONVENTIONS.md` | Need full code style rules, THEORY comment format, test conventions |
 | `STATUS.md` | Need exact current status, implementation table, feature checklist |
 | `roadmap.md` | Need full project phases and timeline |
-| `sprints/sprint11/sprint-plan.md` | Most recent sprint's milestones, issues, acceptance criteria |
-| `sprints/sprint11/sprint-log.md` | What was completed in the latest sprint |
+| `sprints/sprint12/sprint-plan.md` | Most recent sprint's milestones, issues, acceptance criteria |
+| `sprints/sprint12/sprint-log.md` | What was completed in the latest sprint |
 
 ---
 
-*Last updated: 2026-07-02 | Sprint 11 Complete (Milestone 11c) — Phase 2 Complete*
+*Last updated: 2026-07-02 | Sprint 12 Complete (Milestone 12c) — Phase 3 In Progress*

--- a/.ai/STATUS.md
+++ b/.ai/STATUS.md
@@ -8,10 +8,10 @@
 
 | Field | Value |
 |-------|-------|
-| **Phase** | 2 - Network Layer - Complete |
-| **Current Sprint** | 11 (Mempool Sync) - Complete |
-| **Current Milestone** | 11c Complete (Mempool sync on connect) |
-| **Status** | Phase 2 complete (Sprints 8-11), next: Phase 3 (API & Interface) |
+| **Phase** | 3 - API & Interface - In Progress |
+| **Current Sprint** | 12 (REST API) - Complete |
+| **Current Milestone** | 12c Complete (Wallet + network endpoints) |
+| **Status** | Sprint 12 complete (12a-12c), next: Sprint 13 (Web Dashboard) |
 
 ---
 
@@ -46,7 +46,11 @@ Phase 2: Network Layer       [███████████████] 100
 ├── Sprint 10: Broadcasting  ✅ COMPLETE (10a ✅, 10b ✅, 10c ✅, 10d ✅)
 └── Sprint 11: Mempool Sync  ✅ COMPLETE (11a ✅, 11b ✅, 11c ✅)
 
-Phase 3: API & Interface     [░░░░░░░░░░░░░░░] 0% ← NEXT
+Phase 3: API & Interface     [████░░░░░░░░░░░] 25% ← CURRENT
+├── Sprint 12: REST API      ✅ COMPLETE (12a ✅, 12b ✅, 12c ✅)
+├── Sprint 13: Web Dashboard ⬜ ← NEXT
+├── Sprint 14: Smart Contracts ⬜
+└── Sprint 15: Multi-sig Wallets ⬜
 ```
 
 ---
@@ -77,7 +81,10 @@ Phase 3: API & Interface     [░░░░░░░░░░░░░░░] 0% 
 | TransactionBroadcastTest | 4 | ✅ |
 | MempoolPruneTest | 2 | ✅ |
 | MempoolSyncTest | 4 | ✅ |
-| **Total** | **166** | ✅ |
+| ApiReadEndpointsTest | 5 | ✅ |
+| ApiTransactionEndpointsTest | 5 | ✅ |
+| ApiWalletNetworkEndpointsTest | 4 | ✅ |
+| **Total** | **180** | ✅ |
 
 Last test run: `mvn test` - All passing
 
@@ -119,6 +126,12 @@ Last test run: `mvn test` - All passing
 | PeerInfo.java | ✅ Complete | ~110 | Peer metadata tracking (Sprint 9a) |
 | PeerManager.java | ✅ Complete | ~145 | Peer registry, MAX_PEERS enforcement (Sprint 9b) |
 | messages/*.java | ✅ Complete | ~280 | 11 concrete message types (+ GetMempool/Mempool, Sprint 11c) |
+
+### API Classes (`com.blocksmith.api`)
+
+| Class | Status | Lines | Notes |
+|-------|--------|-------|-------|
+| ApiServer.java | ✅ Complete | ~300 | Javalin REST API: blocks, transactions, mining, wallet, network, JSON errors (Sprint 12) |
 
 ### Demo
 
@@ -181,6 +194,11 @@ Last test run: `mvn test` - All passing
 - [x] Prune confirmed transactions from the mempool on append (Sprint 11b)
 - [x] GetMempoolMessage / MempoolMessage for mempool sync (Sprint 11c)
 - [x] GET_MEMPOOL / MEMPOOL handlers + mempool request on connect (Sprint 11c)
+- [x] Javalin REST API server on a dedicated port (Sprint 12a)
+- [x] Block read endpoints + network status (Sprint 12a)
+- [x] Transaction submit/lookup + mining endpoints, broadcast on write (Sprint 12b)
+- [x] Wallet balance/create + peers endpoints (Sprint 12c)
+- [x] Consistent JSON error envelope (400/404/500) (Sprint 12c)
 
 ---
 
@@ -189,7 +207,7 @@ Last test run: `mvn test` - All passing
 | Item | Value |
 |------|-------|
 | **Current Branch** | `master` |
-| **Last Commit** | Sprint 11 complete (mempool sync merged, PR #106) |
+| **Last Commit** | Sprint 12 complete (REST API merged, PR #121) |
 | **Tag** | `v1.0.0` (Phase 1) |
 | **Main Branch** | `master` |
 
@@ -203,25 +221,29 @@ _None currently._
 
 ## 📝 Notes for Next Session
 
-1. **Sprint 11 COMPLETE** - Mempool Sync
-   - All milestones 11a, 11b, 11c merged to master
-   - Transaction gossip (NEW_TRANSACTION), confirmed-tx pruning, and mempool
-     sync on connect (GET_MEMPOOL/MEMPOOL) live
-   - Genesis block is now deterministic, so nodes share a common chain root
+1. **Sprint 12 COMPLETE** - REST API
+   - All milestones 12a, 12b, 12c merged to master
+   - Javalin `ApiServer` on port 7070: blocks, transactions, mining, wallet,
+     network endpoints + JSON error handling
+   - Writes over HTTP (submit tx, mine) propagate to peers via the existing
+     broadcast paths
+   - First dependency beyond Gson/JUnit: `io.javalin:javalin` 6.3.0
 
-2. **Phase 2 COMPLETE** - Network Layer (Sprints 8-11)
-   - P2P networking, node discovery, block broadcasting, mempool sync all done
+2. **Phase 3 IN PROGRESS** - API & Interface (Sprint 12 done, 25%)
 
-3. **Next: Phase 3** - API & Interface
-   - REST API, dashboard/block explorer, and related tooling (Sprints 12+)
-   - Plan Sprint 12 to kick off the phase
+3. **Next: Sprint 13** - Web Dashboard
+   - HTML/JS frontend over the REST API (chain view, wallet UI, live updates)
+   - `ApiServer` is not yet wired into `BlockSmithDemo` / a runnable main - a
+     small entry point that starts a Node + ApiServer would help the dashboard
 
 4. **Deferred / future work**
    - Gossip auto-connect to DISCOVERED peers (needs MAX_PEERS guarding)
    - Self-identification filtering in peer lists
    - Mempool request is sent on outbound connect only; inbound side does not
      yet pull the peer's mempool
+   - API transactions are unsigned (educational); signature-carrying submission
+     would need public-key + signature fields in the request body
 
 ---
 
-*Last updated: 2026-07-02 | Sprint 11 Complete (Milestone 11c) - Phase 2 Complete*
+*Last updated: 2026-07-02 | Sprint 12 Complete (Milestone 12c) - Phase 3 In Progress*

--- a/.ai/roadmap.md
+++ b/.ai/roadmap.md
@@ -28,8 +28,8 @@ Transform BlockSmith from an educational blockchain into a **fully functional di
 │  ├── Block Broadcasting                          ✅ Sprint 10       │
 │  └── Mempool Synchronization                     ✅ Sprint 11       │
 │                                                                     │
-│  PHASE 3: API & Interface (Sprint 12-15)        ░░░░░░░░░░░░ 0% ←NEXT│
-│  ├── REST API                                    ⬜ Sprint 12       │
+│  PHASE 3: API & Interface (Sprint 12-15)        ████░░░░░░░░ 25% ←NOW│
+│  ├── REST API                                    ✅ Sprint 12       │
 │  ├── Web Dashboard                               ⬜ Sprint 13       │
 │  ├── Basic Smart Contracts                       ⬜ Sprint 14       │
 │  └── Multi-signature Wallets                     ⬜ Sprint 15       │
@@ -98,16 +98,16 @@ com.blocksmith.network/
 
 ---
 
-## 🖥️ Phase 3: API & Interface ← NEXT
+## 🖥️ Phase 3: API & Interface 🔄 In Progress (25%)
 
 **Goal:** Add REST API and web dashboard for easy interaction.
 
-| Sprint | Title | Key Deliverables |
-|--------|-------|------------------|
-| 12 | REST API | HTTP endpoints, JSON responses, Swagger docs |
-| 13 | Web Dashboard | HTML/JS frontend, real-time updates, wallet UI |
-| 14 | Smart Contracts | Script interpreter, basic conditions, contract storage |
-| 15 | Multi-sig Wallets | M-of-N signatures, threshold signing |
+| Sprint | Title | Key Deliverables | Status |
+|--------|-------|------------------|--------|
+| 12 | REST API | Javalin HTTP endpoints (blocks, tx, mine, wallet, network), JSON responses | ✅ Complete |
+| 13 | Web Dashboard | HTML/JS frontend, real-time updates, wallet UI | ⬜ Next |
+| 14 | Smart Contracts | Script interpreter, basic conditions, contract storage | ⬜ Planned |
+| 15 | Multi-sig Wallets | M-of-N signatures, threshold signing | ⬜ Planned |
 
 ### API Endpoints (Sprint 12)
 ```

--- a/.ai/sprints/sprint12/sprint-log.md
+++ b/.ai/sprints/sprint12/sprint-log.md
@@ -5,32 +5,66 @@
 | Event | Date |
 |-------|------|
 | **Sprint Start** | 2026-07-02 |
-| **Sprint End** | TBD |
+| **Sprint End** | 2026-07-02 |
 
 ---
 
-## Milestone 12a: HTTP server bootstrap + read/query endpoints - Pending
+## Milestone 12a: HTTP server bootstrap + read/query endpoints - Complete
+
+- Added Javalin (`io.javalin:javalin` 6.3.0, embedded Jetty) - first dependency
+  beyond Gson/JUnit
+- `NetworkConfig.API_PORT` (7070), separate from the P2P port
+- `ApiServer(Node[, port])` with `start()` / `stop()`; JSON via Gson
+- Read endpoints: `GET /api/blocks`, `/blocks/{index}` (400/404), `/blocks/latest`,
+  `/api/network/status`
+- Issues #110, #111, #112 - merged via PR #113
+- Tests: `ApiReadEndpointsTest` (5)
 
 ---
 
-## Milestone 12b: Transaction + mining endpoints - Pending
+## Milestone 12b: Transaction + mining endpoints - Complete
+
+- `POST /api/transactions` - build via constructor (so id/timestamp compute),
+  add + broadcast; 201/400
+- `GET /api/transactions/{id}` - find in mempool or a mined block; 404 otherwise
+- `POST /api/mine` - mine pending txs, broadcast the block, return it
+- Issues #114, #115, #116 - merged via PR #117
+- Tests: `ApiTransactionEndpointsTest` (5)
 
 ---
 
-## Milestone 12c: Wallet + network endpoints + error handling - Pending
+## Milestone 12c: Wallet + network endpoints + error handling - Complete
+
+- `GET /api/wallet/{address}` - balance + pending outgoing (mempool scan)
+- `POST /api/wallet/create` - returns the address only (never the private key)
+- `GET /api/network/peers` - connected peers
+- JSON error envelope: 500 for uncaught exceptions, 404 JSON for unmatched routes
+  (explicit handler 404s preserved)
+- Issues #118, #119, #120 - merged via PR #121
+- Tests: `ApiWalletNetworkEndpointsTest` (4)
+
+---
+
+## Outcome
+
+- **Sprint 12 complete** (12a-12c): a fully usable REST API sits beside the P2P
+  node - browse the chain, submit/look up transactions, mine, create wallets,
+  check balances, inspect peers, all over HTTP
+- Writes over HTTP propagate to peers via the existing Sprint 10/11 broadcast paths
+- **Phase 3 now in progress** (25%)
+- Test count: 166 -> 180 (+14)
 
 ---
 
 ## Notes
 
-- First sprint of Phase 3 (API & Interface); Phase 2 completed at Sprint 11
-- Continuing issue-first, milestone-per-branch workflow from Sprints 8-11
-- **HTTP framework pending final confirmation**: Javalin (recommended, roadmap's
-  first-named option) vs built-in `com.sun.net.httpserver` (zero-dependency) vs
-  Spark. The Maven dependency + code are held until confirmed
-- The API sits beside the P2P layer and drives the same Blockchain/Node, so
-  actions taken over HTTP propagate to peers via the existing broadcast paths
+- First sprint of Phase 3 (API & Interface)
+- Continued issue-first, milestone-per-branch workflow from Sprints 8-11
+- Framework confirmed: Javalin (the roadmap's first-named option)
+- Follow-ups: `ApiServer` is not yet wired into a runnable main/demo; API
+  transactions are unsigned (educational) - signed submission would need
+  public-key + signature fields in the request body
 
 ---
 
-*Created: 2026-07-02*
+*Created: 2026-07-02 | Completed: 2026-07-02*

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ BlockSmith is a comprehensive blockchain project that goes beyond tutorials - im
 
 [![Java](https://img.shields.io/badge/Java-20+-orange.svg)](https://openjdk.org/)
 [![Maven](https://img.shields.io/badge/Maven-3.9+-blue.svg)](https://maven.apache.org/)
-[![Tests](https://img.shields.io/badge/Tests-166%20passing-brightgreen.svg)](#)
+[![Tests](https://img.shields.io/badge/Tests-180%20passing-brightgreen.svg)](#)
 [![Phase](https://img.shields.io/badge/Phase%202-In%20Progress-yellow.svg)](#)
 [![Version](https://img.shields.io/badge/Version-1.0.0-blue.svg)](#)
 
@@ -49,12 +49,14 @@ BlockSmith is a comprehensive blockchain project that goes beyond tutorials - im
   - ✅ Prune confirmed transactions from the mempool (Sprint 11b)
   - ✅ Mempool sync on connect (GET_MEMPOOL/MEMPOOL) (Sprint 11c)
 
-### Phase 3: API & Interface 🔜 Planned
-- REST API for blockchain interaction
-- Web dashboard for monitoring
-- BlockExplorer UI
-- Basic smart contract support
-- Multi-signature wallets
+### Phase 3: API & Interface 🔄 In Progress (25%)
+- ✅ REST API for blockchain interaction (Sprint 12)
+  - ✅ Javalin server + block read endpoints (Sprint 12a)
+  - ✅ Transaction submit/lookup + mining endpoints (Sprint 12b)
+  - ✅ Wallet + network endpoints + JSON errors (Sprint 12c)
+- 🔜 Web dashboard for monitoring (Sprint 13)
+- 🔜 Basic smart contract support (Sprint 14)
+- 🔜 Multi-signature wallets (Sprint 15)
 
 ### Phase 4: Production Features 🔜 Planned
 - Database persistence (SQLite)
@@ -196,7 +198,7 @@ Average attempts: ~16^difficulty (~65,536 for difficulty 4)
 mvn clean compile
 ```
 
-### Run all tests (166 tests)
+### Run all tests (180 tests)
 ```bash
 mvn test
 ```
@@ -252,7 +254,7 @@ BlockSmith/
 │   │   ├── PeerManager.java   # Peer registry with MAX_PEERS enforcement
 │   │   └── messages/           # Concrete message classes (incl. GetPeers/Peers)
 │   └── BlockSmithDemo.java     # Main demo application
-├── src/test/java/              # 166 unit tests
+├── src/test/java/              # 180 unit tests
 ├── data/                       # Blockchain persistence (JSON)
 ├── pom.xml                     # Maven configuration
 └── README.md
@@ -286,7 +288,10 @@ BlockSmith/
 | TransactionBroadcastTest | 4 | NEW_TRANSACTION serialization and handler |
 | MempoolPruneTest | 2 | Confirmed-tx pruning on block append |
 | MempoolSyncTest | 4 | GET_MEMPOOL/MEMPOOL sync handlers |
-| **Total** | **166** | All passing ✅ |
+| ApiReadEndpointsTest | 5 | REST block/status read endpoints |
+| ApiTransactionEndpointsTest | 5 | REST transaction submit/lookup + mining |
+| ApiWalletNetworkEndpointsTest | 4 | REST wallet/network endpoints + JSON errors |
+| **Total** | **180** | All passing ✅ |
 
 ---
 
@@ -298,6 +303,11 @@ BlockSmith/
 - Proof-of-Work consensus
 - Merkle trees & data structures
 - Transaction pools (mempool)
+
+### Networking & API
+- TCP socket P2P networking
+- JSON messaging (Gson)
+- REST API over HTTP (Javalin / embedded Jetty)
 
 ### Java
 - Java Cryptography Architecture (JCA)
@@ -335,10 +345,13 @@ BlockSmith/
 | Sprint 10 | Block Broadcasting | ✅ Complete (10a, 10b, 10c, 10d) |
 | Sprint 11 | Mempool Sync | ✅ Complete (11a, 11b, 11c) |
 
-### Phase 3: API & Interface
+### Phase 3: API & Interface 🔄 In Progress (25%)
 | Sprint | Title | Status |
 |--------|-------|--------|
-| Sprint 12-15 | REST API, Dashboard, Contracts | ⬜ Planned |
+| Sprint 12 | REST API | ✅ Complete (12a, 12b, 12c) |
+| Sprint 13 | Web Dashboard | ⬜ Planned |
+| Sprint 14 | Smart Contracts | ⬜ Planned |
+| Sprint 15 | Multi-sig Wallets | ⬜ Planned |
 
 ### Phase 4: Production
 | Sprint | Title | Status |
@@ -367,4 +380,4 @@ This project is for educational purposes.
 
 ---
 
-*Last updated: 2026-07-02 | Phase 2 Complete (Sprint 11 - Mempool Sync)*
+*Last updated: 2026-07-02 | Phase 3 In Progress (Sprint 12 - REST API Complete)*


### PR DESCRIPTION
## Summary
Marks Sprint 12 (REST API) complete and opens Phase 3 (API & Interface) across all project docs, following the established per-sprint pattern (and keeping ONBOARDING/roadmap current so they don't drift).

- **STATUS.md**: phase/sprint/milestone -> Phase 3 in progress, Sprint 12 complete; progress block adds Phase 3 at 25%; test summary 166 -> 180 (3 new API test classes); new `com.blocksmith.api` implementation section; feature list, git status, and next-session notes updated (next: Sprint 13 Web Dashboard).
- **README.md**: tests badge/counts 166 -> 180, Phase 3 feature list + roadmap show Sprint 12 complete, coverage table extended, Networking & API tech section adds Javalin.
- **roadmap.md**: Phase 3 overview 0% -> 25%, Sprint 12 done, Phase 3 header In Progress.
- **ONBOARDING.md**: quick reference, structure (api package), implemented list, test table, latest-commit and deep-dive pointers refreshed to Sprint 12.
- **sprint12/sprint-log.md**: all three milestones (12a-12c) written up with issues/PRs and tests.

## Test plan
- [x] Docs-only change; `mvn test` already green at 180 from PR #121