### PR TITLE
docs: Sprint 13 plan (Web Dashboard)

### DIFF
--- a/.ai/sprints/sprint13/github-issues.md
+++ b/.ai/sprints/sprint13/github-issues.md
@@ -1,0 +1,160 @@
+# Sprint 13: GitHub Issues
+
+> Copy each issue to GitHub. Actual issue numbers are assigned on creation
+> (PRs consume the same number space, so they will not be contiguous).
+
+---
+
+## Milestone 13a: Runnable node entry point + static hosting
+
+---
+
+### Add a runnable node entry point (Node + ApiServer)
+
+**Labels:** `sprint-13`, `milestone-13a`, `enhancement`
+
+**Description:**
+
+Add a `main` that starts a `Node` and an `ApiServer` together so the project is
+runnable as a single process.
+
+- `BlockSmithNode` (or similar) with a `main` that boots both
+- Ports from `NetworkConfig` (P2P + API); optionally overridable via args
+- Clean shutdown hook
+
+**Acceptance Criteria:**
+- [ ] Running the entry point starts the P2P node and the REST API
+- [ ] Compiles with `mvn compile`
+
+---
+
+### Serve static files + dashboard shell from Javalin
+
+**Labels:** `sprint-13`, `milestone-13a`, `enhancement`
+
+**Description:**
+
+- Configure Javalin static-file hosting (e.g. `src/main/resources/public`)
+- `GET /` serves `index.html` (a placeholder shell for now)
+- Ensure `/api/*` still routes to the API alongside static hosting
+
+**Acceptance Criteria:**
+- [ ] `GET /` returns 200 with HTML
+- [ ] A static asset (e.g. `/style.css`) is served
+- [ ] API endpoints still work
+- [ ] Compiles with `mvn compile`
+
+---
+
+### Tests for entry point + static hosting
+
+**Labels:** `sprint-13`, `milestone-13a`, `test`
+
+**Description:**
+
+**Test Cases:**
+1. `root_servesHtmlShell`
+2. `staticAsset_isServed`
+3. `apiStillRespondsAlongsideStatic`
+
+**Acceptance Criteria:**
+- [ ] Tests added and passing
+- [ ] All existing tests still passing
+- [ ] `mvn test` green
+
+---
+
+## Milestone 13b: Explorer view (blocks + network)
+
+---
+
+### Build the explorer dashboard (blocks + network panel)
+
+**Labels:** `sprint-13`, `milestone-13b`, `enhancement`
+
+**Description:**
+
+`index.html` + `app.js` + `style.css`:
+- Blocks view from `GET /api/blocks` (index, hash, prevHash, tx count, nonce),
+  latest highlighted
+- Network panel from `GET /api/network/status` and `GET /api/network/peers`
+- Auto-refresh via polling (configurable interval)
+
+**Acceptance Criteria:**
+- [ ] Dashboard renders the chain and network state
+- [ ] Auto-refreshes without a manual reload
+- [ ] Compiles with `mvn compile`
+
+---
+
+### Tests for the explorer (server-side)
+
+**Labels:** `sprint-13`, `milestone-13b`, `test`
+
+**Description:**
+
+**Test Cases:**
+1. `indexHtml_containsExpectedMountPoints`
+2. `blocksEndpoint_shapeMatchesUiExpectations` (fields the UI reads exist)
+
+**Acceptance Criteria:**
+- [ ] Tests added and passing
+- [ ] `mvn test` green
+
+---
+
+## Milestone 13c: Wallet + transaction actions
+
+---
+
+### Add wallet + transaction actions to the dashboard
+
+**Labels:** `sprint-13`, `milestone-13c`, `enhancement`
+
+**Description:**
+
+- Create-wallet button -> `POST /api/wallet/create`, show the address
+- Balance lookup -> `GET /api/wallet/{address}`
+- Submit-transaction form -> `POST /api/transactions`
+- Mine button -> `POST /api/mine`, then refresh the chain
+- Surface API error envelopes in the UI
+
+**Acceptance Criteria:**
+- [ ] A user can create a wallet, check a balance, submit a tx, and mine from the UI
+- [ ] Errors are shown to the user
+- [ ] Compiles with `mvn compile`
+
+---
+
+### Tests for dashboard actions (server-side glue)
+
+**Labels:** `sprint-13`, `milestone-13c`, `test`
+
+**Description:**
+
+**Test Cases:**
+1. `dashboardActionEndpoints_behaveAsExpected` (any new glue; core paths already
+   covered by Sprint 12 tests)
+
+**Acceptance Criteria:**
+- [ ] Tests added and passing
+- [ ] All existing tests still passing
+- [ ] `mvn test` green
+
+---
+
+## Summary
+
+| Milestone | Issues | Tests |
+|-----------|--------|-------|
+| 13a: Entry point + static hosting | 3 | 3 tests |
+| 13b: Explorer view | 2 | ~2 tests |
+| 13c: Wallet + tx actions | 2 | ~1 test |
+| **Total** | **7 issues** | **~6 tests** |
+
+> Test counts are lower than the backend sprints: the browser UI is verified by
+> running it, so automated coverage focuses on the server side.
+
+---
+
+*Created: 2026-07-02 | Sprint 13 Planning*

--- a/.ai/sprints/sprint13/sprint-log.md
+++ b/.ai/sprints/sprint13/sprint-log.md
@@ -1,0 +1,36 @@
+# Sprint 13: Web Dashboard - Log
+
+## Sprint Timeline
+
+| Event | Date |
+|-------|------|
+| **Sprint Start** | TBD |
+| **Sprint End** | TBD |
+
+---
+
+## Milestone 13a: Runnable node entry point + static hosting - Pending
+
+---
+
+## Milestone 13b: Explorer view (blocks + network) - Pending
+
+---
+
+## Milestone 13c: Wallet + transaction actions - Pending
+
+---
+
+## Notes
+
+- Second sprint of Phase 3 (API & Interface); Sprint 12 delivered the REST API
+- Approach: vanilla HTML/JS/CSS, no build step, served by Javalin static hosting;
+  polling refresh (WebSocket push is a possible later enhancement)
+- Closes the "no runnable main" gap noted after Sprint 12: 13a boots Node +
+  ApiServer as a single process
+- Testing reality: the browser UI is verified by running it, so automated tests
+  focus on the server side (static serving + the endpoints the UI consumes)
+
+---
+
+*Created: 2026-07-02*

--- a/.ai/sprints/sprint13/sprint-plan.md
+++ b/.ai/sprints/sprint13/sprint-plan.md
@@ -1,0 +1,127 @@
+# Sprint 13: Web Dashboard
+
+## Sprint Info
+
+| Field | Value |
+|-------|-------|
+| **Sprint** | 13 |
+| **Title** | Web Dashboard |
+| **Phase** | Phase 3: API & Interface |
+| **Status** | Planning |
+| **Depends On** | Sprint 12 Complete (REST API) |
+
+> **Approach (recommended):** vanilla HTML/JS/CSS with **no framework and no
+> build step**, served directly by Javalin's static-file handler. Refresh via
+> **polling** (re-fetch the REST API every few seconds) rather than WebSockets -
+> simpler and enough for a demo; WebSocket push can be a later enhancement. No
+> new dependency is added.
+
+---
+
+## Goal
+
+Put a human face on the node. A browser dashboard, served by the node itself,
+lets a user watch the chain grow, inspect blocks and network state, create a
+wallet, check a balance, submit a transaction, and mine - all through the REST
+API from Sprint 12. By the end of this sprint the project is demoable end to
+end: start a node, open a browser, and drive the blockchain.
+
+---
+
+## Milestones
+
+| Milestone | Title | Branch | Status |
+|-----------|-------|--------|--------|
+| **13a** | Runnable node entry point + static hosting | `sprint13a/node-runner` | Pending |
+| **13b** | Explorer view (blocks + network) | `sprint13b/explorer-ui` | Pending |
+| **13c** | Wallet + transaction actions | `sprint13c/wallet-ui` | Pending |
+
+---
+
+## Milestone 13a: Runnable node entry point + static hosting
+
+### Deliverables
+
+- [ ] A runnable entry point (e.g. `BlockSmithNode` main) that starts a `Node`
+      and an `ApiServer` together, with ports from `NetworkConfig`
+- [ ] Configure Javalin to serve static files (e.g. from `src/main/resources/public`)
+- [ ] `GET /` serves the dashboard shell (`index.html`)
+- [ ] Tests (server-side): `GET /` returns 200 HTML; a static asset is served;
+      the API still responds alongside static hosting
+
+### Why this is first
+
+There is currently no single command that boots a node with its API, and no
+static hosting. The dashboard needs both, so this is the foundation.
+
+---
+
+## Milestone 13b: Explorer view (blocks + network)
+
+### Deliverables
+
+- [ ] `index.html` + `app.js` + `style.css` under the static folder
+- [ ] Blocks view: fetch `GET /api/blocks`, render index / hash / prevHash /
+      tx count / nonce; highlight the latest block
+- [ ] Network panel: fetch `GET /api/network/status` and `GET /api/network/peers`
+      (chain length, pending count, peers)
+- [ ] Auto-refresh via polling (configurable interval)
+- [ ] Tests (server-side): the served `index.html` includes the expected mount
+      points; endpoints the UI depends on return the expected shape
+
+### Note on testing
+
+The UI itself is verified by running the node and opening the browser. Automated
+coverage focuses on the server side (static serving + the endpoints the UI
+consumes), so this sprint has fewer unit tests than the backend sprints.
+
+---
+
+## Milestone 13c: Wallet + transaction actions
+
+### Deliverables
+
+- [ ] Create-wallet button -> `POST /api/wallet/create`, show the new address
+- [ ] Balance lookup -> `GET /api/wallet/{address}`
+- [ ] Submit-transaction form (sender, recipient, amount) -> `POST /api/transactions`
+- [ ] Mine button (miner address) -> `POST /api/mine`, then refresh the chain
+- [ ] Surface API errors (the JSON error envelope) in the UI
+- [ ] Tests (server-side): the action endpoints behave as the UI expects
+      (already covered by Sprint 12 tests; add any dashboard-specific glue)
+
+---
+
+## Theory: A node that serves its own UI
+
+```
+Sprint 12 gave the node an HTTP/JSON API. Sprint 13 serves a small web app from
+that SAME Javalin instance:
+
+  Browser --GET /-------------------> index.html (static)
+  Browser --GET /api/blocks--------->  ApiServer -> Blockchain
+  Browser --POST /api/transactions->  ApiServer -> addTransaction -> broadcast
+
+Because the page is served from the same origin as the API, there is no CORS to
+configure. The dashboard is just another API client - the difference is a human
+is driving it. Actions still propagate to peers via the P2P broadcast paths.
+```
+
+---
+
+## Dependencies
+
+- Sprint 12 REST API (`ApiServer` and all endpoints)
+- Javalin static-file hosting (already on the classpath)
+- No new dependency; no JS build tooling
+
+---
+
+## Open decisions
+
+- **Frontend**: vanilla HTML/JS/CSS, no build (recommended) vs a framework
+- **Real-time**: polling (recommended) vs WebSocket push
+- **Static location**: `src/main/resources/public` (bundled on the classpath)
+
+---
+
+*Created: 2026-07-02 | Sprint 13 Planning*


### PR DESCRIPTION
## Summary
Plans Sprint 13 (Web Dashboard), the second sprint of Phase 3, following the established planning format.

- **sprint-plan.md**: goal, three milestones (13a runnable entry point + static hosting, 13b explorer view, 13c wallet + transaction actions), deliverables, theory (node serves its own UI, same-origin so no CORS), dependencies, open decisions.
- **github-issues.md**: copy-ready text for all 7 issues.
- **sprint-log.md**: milestone skeleton.

## Approach (recommended, no new dependency)
- Vanilla HTML/JS/CSS, **no framework, no build step**, served by Javalin static hosting.
- **Polling** refresh (WebSocket push is a possible later enhancement).
- 13a also closes the "no runnable main" gap flagged after Sprint 12.

## Note on testing
A browser UI is verified by running it, so automated coverage focuses on the server side (static serving + endpoints the UI consumes). Expect fewer unit tests than the backend sprints (~6 vs ~10).

## Test plan
- [x] Docs-only change