### PR TITLE
Sprint 13a: runnable node entry point + static dashboard hosting

### DIFF
--- a/src/main/java/com/blocksmith/BlockSmithNode.java
+++ b/src/main/java/com/blocksmith/BlockSmithNode.java
@@ -1,0 +1,45 @@
+package com.blocksmith;
+
+import com.blocksmith.api.ApiServer;
+import com.blocksmith.network.NetworkConfig;
+import com.blocksmith.network.Node;
+
+/**
+ * Runnable entry point that boots a full BlockSmith node in one process:
+ * the P2P {@link Node} (TCP gossip with peers) and the {@link ApiServer}
+ * (HTTP/JSON API + web dashboard for users).
+ *
+ * <p>Usage:
+ * <pre>
+ *   java -cp target/classes com.blocksmith.BlockSmithNode [p2pPort] [apiPort]
+ * </pre>
+ * Ports default to {@link NetworkConfig#DEFAULT_PORT} and
+ * {@link NetworkConfig#API_PORT}.
+ */
+public class BlockSmithNode {
+
+    public static void main(String[] args) throws java.io.IOException {
+        int p2pPort = args.length > 0 ? Integer.parseInt(args[0]) : NetworkConfig.DEFAULT_PORT;
+        int apiPort = args.length > 1 ? Integer.parseInt(args[1]) : NetworkConfig.API_PORT;
+
+        Node node = new Node(p2pPort);
+        node.start();
+
+        ApiServer api = new ApiServer(node, apiPort);
+        api.start();
+
+        System.out.println("BlockSmith node is running:");
+        System.out.println("  P2P      : port " + p2pPort);
+        System.out.println("  API      : http://localhost:" + apiPort + "/api");
+        System.out.println("  Dashboard: http://localhost:" + apiPort + "/");
+
+        // Stop both cleanly on Ctrl+C / shutdown.
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            System.out.println("\nShutting down BlockSmith node...");
+            api.stop();
+            node.stop();
+        }));
+    }
+
+    private BlockSmithNode() {}
+}

--- a/src/main/java/com/blocksmith/api/ApiServer.java
+++ b/src/main/java/com/blocksmith/api/ApiServer.java
@@ -19,6 +19,7 @@ import com.google.gson.JsonSyntaxException;
 
 import io.javalin.Javalin;
 import io.javalin.http.Context;
+import io.javalin.http.staticfiles.Location;
 
 /**
  * THEORY: REST API in front of a P2P node.
@@ -56,7 +57,12 @@ public class ApiServer {
 
     /** Starts the HTTP server and registers routes. */
     public void start() {
-        app = Javalin.create(config -> config.showJavalinBanner = false);
+        app = Javalin.create(config -> {
+            config.showJavalinBanner = false;
+            // Serve the web dashboard from the classpath (src/main/resources/public).
+            // API routes take precedence; "/" falls through to index.html.
+            config.staticFiles.add("/public", Location.CLASSPATH);
+        });
         registerRoutes();
         app.start(port);
     }

--- a/src/main/resources/public/index.html
+++ b/src/main/resources/public/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>BlockSmith Dashboard</title>
+    <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+    <header>
+        <h1>BlockSmith</h1>
+        <p class="tagline">A blockchain node dashboard</p>
+    </header>
+
+    <main>
+        <!-- Explorer view (blocks + network) is filled in during Sprint 13b. -->
+        <section id="network"></section>
+        <section id="blocks"></section>
+    </main>
+
+    <footer>
+        <p>Served by the node's REST API &middot; Sprint 13a</p>
+    </footer>
+</body>
+</html>

--- a/src/main/resources/public/style.css
+++ b/src/main/resources/public/style.css
@@ -1,0 +1,58 @@
+/* BlockSmith dashboard styles (Sprint 13). */
+
+:root {
+    --bg: #0f1420;
+    --panel: #1a2130;
+    --text: #e6edf3;
+    --muted: #8b98a9;
+    --accent: #f5a623;
+    --border: #2a3446;
+}
+
+* { box-sizing: border-box; }
+
+body {
+    margin: 0;
+    font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.5;
+}
+
+header {
+    padding: 1.5rem 2rem;
+    border-bottom: 1px solid var(--border);
+}
+
+header h1 {
+    margin: 0;
+    color: var(--accent);
+    letter-spacing: 0.5px;
+}
+
+.tagline {
+    margin: 0.25rem 0 0;
+    color: var(--muted);
+}
+
+main {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 2rem;
+    display: grid;
+    gap: 1.5rem;
+}
+
+section {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1.25rem;
+}
+
+footer {
+    padding: 1.5rem 2rem;
+    border-top: 1px solid var(--border);
+    color: var(--muted);
+    text-align: center;
+}

--- a/src/test/java/com/blocksmith/api/ApiStaticHostingTest.java
+++ b/src/test/java/com/blocksmith/api/ApiStaticHostingTest.java
@@ -1,0 +1,88 @@
+package com.blocksmith.api;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.blocksmith.network.Node;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for Milestone 13a: the ApiServer serves the static web dashboard
+ * alongside the REST API (both from the same Javalin instance).
+ */
+@DisplayName("API Static Hosting Tests")
+class ApiStaticHostingTest {
+
+    private static final int API_PORT_BASE = 17300;
+    private static final int P2P_PORT_BASE = 18800;
+    private static int counter = 0;
+
+    private Node node;
+    private ApiServer api;
+    private int apiPort;
+    private final HttpClient client = HttpClient.newHttpClient();
+
+    @BeforeEach
+    void setUp() {
+        int offset = counter++;
+        apiPort = API_PORT_BASE + offset;
+        node = new Node(P2P_PORT_BASE + offset);
+        api = new ApiServer(node, apiPort);
+        api.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (api != null) api.stop();
+        if (node != null) node.stop();
+    }
+
+    private HttpResponse<String> get(String path) throws Exception {
+        return client.send(
+                HttpRequest.newBuilder()
+                        .uri(URI.create("http://localhost:" + apiPort + path))
+                        .GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    @Test
+    @DisplayName("GET / serves the HTML dashboard shell")
+    void root_servesHtmlShell() throws Exception {
+        HttpResponse<String> res = get("/");
+
+        assertEquals(200, res.statusCode(), "Root should return 200");
+        assertTrue(res.body().contains("BlockSmith"),
+                "Dashboard shell should mention BlockSmith");
+        assertTrue(res.body().contains("<html"),
+                "Response should be an HTML document");
+    }
+
+    @Test
+    @DisplayName("Static assets are served")
+    void staticAsset_isServed() throws Exception {
+        HttpResponse<String> res = get("/style.css");
+
+        assertEquals(200, res.statusCode(), "Static CSS should be served");
+        assertFalse(res.body().isBlank(), "CSS body should not be empty");
+    }
+
+    @Test
+    @DisplayName("The REST API still responds alongside static hosting")
+    void apiStillRespondsAlongsideStatic() throws Exception {
+        HttpResponse<String> res = get("/api/network/status");
+
+        assertEquals(200, res.statusCode(), "API should still respond");
+        JsonObject status = JsonParser.parseString(res.body()).getAsJsonObject();
+        assertTrue(status.has("chainLength"), "Status JSON should be intact");
+    }
+}


### PR DESCRIPTION
## Summary
First milestone of Sprint 13. Makes the project runnable as a single process and lets the node serve its own web dashboard.

- `BlockSmithNode` - a `main` that boots the P2P `Node` and the `ApiServer` together (ports from `NetworkConfig`, optionally overridable via args), with a shutdown hook.
- `ApiServer` now configures Javalin static-file hosting from the classpath (`src/main/resources/public`); `GET /` serves the dashboard shell, `/api/*` still routes to the API.
- Placeholder dashboard shell: `index.html` + `style.css` (explorer/wallet UI arrives in 13b/13c).
- 3 new tests (`ApiStaticHostingTest`): root serves HTML, static asset served, API coexists with static hosting.

## Try it
```
mvn -q compile ; java -cp target/classes com.blocksmith.BlockSmithNode
# then open http://localhost:7070/
```

## Test plan
- [x] `mvn test` green - 183 tests passing
- [x] `mvn compile` clean

Closes #124
Closes #125
Closes #126