### PR TITLE
Sprint 13b: explorer dashboard (blocks + network)

### DIFF
--- a/src/main/resources/public/app.js
+++ b/src/main/resources/public/app.js
@@ -1,0 +1,108 @@
+/*
+ * BlockSmith dashboard - explorer view (Sprint 13b).
+ *
+ * Vanilla JS, no build step. Polls the REST API and renders the chain and
+ * network state. Values are written with textContent (never innerHTML) so
+ * data from the node can never inject markup.
+ */
+
+const REFRESH_MS = 4000;
+
+/** Fetches JSON from the node's API, throwing on a non-2xx response. */
+async function fetchJson(path) {
+    const res = await fetch(path);
+    if (!res.ok) throw new Error(path + " -> HTTP " + res.status);
+    return res.json();
+}
+
+/** Small DOM helper: element with optional class and text. */
+function el(tag, className, text) {
+    const node = document.createElement(tag);
+    if (className) node.className = className;
+    if (text !== undefined) node.textContent = text;
+    return node;
+}
+
+/** Renders a labelled stat tile. */
+function statTile(label, value) {
+    const tile = el("div", "stat");
+    tile.appendChild(el("span", "stat-value", String(value)));
+    tile.appendChild(el("span", "stat-label", label));
+    return tile;
+}
+
+function renderNetwork(status, peers) {
+    const stats = document.getElementById("network-stats");
+    stats.replaceChildren(
+        statTile("Chain length", status.chainLength),
+        statTile("Pending tx", status.pendingTransactions),
+        statTile("Peers", status.connectedPeers)
+    );
+
+    const peersBox = document.getElementById("peers");
+    peersBox.replaceChildren();
+    const heading = el("p", "peers-heading", "Node " + status.nodeId
+        + " · P2P " + status.p2pPort + " · API " + status.apiPort);
+    peersBox.appendChild(heading);
+
+    if (peers.length === 0) {
+        peersBox.appendChild(el("p", "muted", "No connected peers"));
+        return;
+    }
+    peers.forEach(function (p) {
+        peersBox.appendChild(el("div", "peer", p.address + "  (" + p.state + ")"));
+    });
+}
+
+/** Short hash for display: first 10 + last 6 hex chars. */
+function shortHash(hash) {
+    if (!hash || hash.length <= 20) return hash;
+    return hash.slice(0, 10) + "…" + hash.slice(-6);
+}
+
+function renderBlocks(blocks) {
+    const list = document.getElementById("block-list");
+    list.replaceChildren();
+
+    // Newest first; the tip is highlighted.
+    const tipIndex = blocks.length - 1;
+    for (let i = tipIndex; i >= 0; i--) {
+        const block = blocks[i];
+        const card = el("div", i === tipIndex ? "block latest" : "block");
+
+        const head = el("div", "block-head");
+        head.appendChild(el("span", "block-index", "#" + block.index));
+        const txCount = Array.isArray(block.transactions) ? block.transactions.length : 0;
+        head.appendChild(el("span", "block-txs", txCount + " tx"));
+        card.appendChild(head);
+
+        card.appendChild(el("div", "block-hash", "hash " + shortHash(block.hash)));
+        card.appendChild(el("div", "block-prev", "prev " + shortHash(block.previousHash)));
+        card.appendChild(el("div", "block-nonce", "nonce " + block.nonce));
+        list.appendChild(card);
+    }
+}
+
+function setStatus(text, ok) {
+    const bar = document.getElementById("refresh-status");
+    bar.textContent = text;
+    bar.classList.toggle("error", !ok);
+}
+
+async function refresh() {
+    try {
+        const [status, peers, blocks] = await Promise.all([
+            fetchJson("/api/network/status"),
+            fetchJson("/api/network/peers"),
+            fetchJson("/api/blocks")
+        ]);
+        renderNetwork(status, peers);
+        renderBlocks(blocks);
+        setStatus("Updated · refreshing every " + (REFRESH_MS / 1000) + "s", true);
+    } catch (e) {
+        setStatus("Cannot reach the node API: " + e.message, false);
+    }
+}
+
+refresh();
+setInterval(refresh, REFRESH_MS);

--- a/src/main/resources/public/index.html
+++ b/src/main/resources/public/index.html
@@ -13,13 +13,22 @@
     </header>
 
     <main>
-        <!-- Explorer view (blocks + network) is filled in during Sprint 13b. -->
-        <section id="network"></section>
-        <section id="blocks"></section>
+        <section id="network">
+            <h2>Network</h2>
+            <div id="network-stats" class="stats"></div>
+            <div id="peers"></div>
+        </section>
+
+        <section id="blocks">
+            <h2>Blocks</h2>
+            <div id="block-list"></div>
+        </section>
     </main>
 
     <footer>
-        <p>Served by the node's REST API &middot; Sprint 13a</p>
+        <p id="refresh-status" class="refresh">Connecting&hellip;</p>
     </footer>
+
+    <script src="/app.js"></script>
 </body>
 </html>

--- a/src/main/resources/public/style.css
+++ b/src/main/resources/public/style.css
@@ -50,9 +50,102 @@ section {
     padding: 1.25rem;
 }
 
+section h2 {
+    margin: 0 0 1rem;
+    font-size: 1.1rem;
+    color: var(--text);
+}
+
+/* Network stats */
+.stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+}
+
+.stat {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 0.75rem;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+}
+
+.stat-value {
+    font-size: 1.6rem;
+    font-weight: 700;
+    color: var(--accent);
+}
+
+.stat-label {
+    font-size: 0.8rem;
+    color: var(--muted);
+}
+
+.peers-heading {
+    font-family: ui-monospace, "Cascadia Code", Consolas, monospace;
+    font-size: 0.8rem;
+    color: var(--muted);
+    margin: 0 0 0.5rem;
+    word-break: break-all;
+}
+
+.peer {
+    font-family: ui-monospace, Consolas, monospace;
+    font-size: 0.85rem;
+    padding: 0.25rem 0;
+}
+
+.muted { color: var(--muted); }
+
+/* Block cards */
+#block-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 0.75rem;
+}
+
+.block {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.75rem;
+    font-family: ui-monospace, Consolas, monospace;
+    font-size: 0.8rem;
+}
+
+.block.latest {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 1px var(--accent);
+}
+
+.block-head {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 0.5rem;
+}
+
+.block-index {
+    font-weight: 700;
+    color: var(--accent);
+    font-size: 1rem;
+}
+
+.block-txs { color: var(--muted); }
+
+.block-hash, .block-prev, .block-nonce {
+    color: var(--muted);
+    word-break: break-all;
+}
+
 footer {
     padding: 1.5rem 2rem;
     border-top: 1px solid var(--border);
     color: var(--muted);
     text-align: center;
 }
+
+.refresh.error { color: #ff6b6b; }

--- a/src/test/java/com/blocksmith/api/ApiExplorerTest.java
+++ b/src/test/java/com/blocksmith/api/ApiExplorerTest.java
@@ -1,0 +1,84 @@
+package com.blocksmith.api;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.blocksmith.network.Node;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Server-side tests for the Milestone 13b explorer view. The dashboard itself
+ * is verified by running it; here we check the shell exposes the mount points
+ * app.js targets and that the blocks endpoint carries the fields the UI reads.
+ */
+@DisplayName("API Explorer Tests")
+class ApiExplorerTest {
+
+    private static final int API_PORT_BASE = 17400;
+    private static final int P2P_PORT_BASE = 18900;
+    private static int counter = 0;
+
+    private Node node;
+    private ApiServer api;
+    private int apiPort;
+    private final HttpClient client = HttpClient.newHttpClient();
+
+    @BeforeEach
+    void setUp() {
+        int offset = counter++;
+        apiPort = API_PORT_BASE + offset;
+        node = new Node(P2P_PORT_BASE + offset);
+        api = new ApiServer(node, apiPort);
+        api.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (api != null) api.stop();
+        if (node != null) node.stop();
+    }
+
+    private HttpResponse<String> get(String path) throws Exception {
+        return client.send(
+                HttpRequest.newBuilder()
+                        .uri(URI.create("http://localhost:" + apiPort + path))
+                        .GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    @Test
+    @DisplayName("Served index.html exposes the mount points app.js targets")
+    void indexHtml_containsExpectedMountPoints() throws Exception {
+        String html = get("/").body();
+
+        assertTrue(html.contains("id=\"network-stats\""), "Needs the network-stats mount point");
+        assertTrue(html.contains("id=\"block-list\""), "Needs the block-list mount point");
+        assertTrue(html.contains("/app.js"), "Should load the dashboard script");
+    }
+
+    @Test
+    @DisplayName("Blocks endpoint carries the fields the explorer reads")
+    void blocksEndpoint_shapeMatchesUiExpectations() throws Exception {
+        node.getBlockchain().addBlock("explorer");
+
+        JsonArray blocks = JsonParser.parseString(get("/api/blocks").body()).getAsJsonArray();
+        assertFalse(blocks.isEmpty(), "Chain should have at least the genesis block");
+
+        JsonObject block = blocks.get(blocks.size() - 1).getAsJsonObject();
+        for (String field : new String[]{"index", "hash", "previousHash", "nonce", "transactions"}) {
+            assertTrue(block.has(field), "Block JSON should include '" + field + "' for the UI");
+        }
+        assertTrue(block.get("transactions").isJsonArray(), "transactions should be an array");
+    }
+}


### PR DESCRIPTION
## Summary
The dashboard comes to life. Vanilla JS (no build step) fetches the REST API and renders the chain and network state, auto-refreshing via polling.

- `app.js` - polls `/api/network/status`, `/api/network/peers`, and `/api/blocks` every 4s; renders network stat tiles, peer list, and block cards (newest first, tip highlighted). Values written with `textContent` (never `innerHTML`) so node data can't inject markup.
- `index.html` - explorer shell with `network-stats` / `peers` / `block-list` mount points, loads `/app.js`.
- `style.css` - stat tiles, block cards, peer list, error state for the refresh bar.
- 2 server-side tests (`ApiExplorerTest`): index.html exposes the mount points app.js targets; the blocks endpoint carries the fields the UI reads (index, hash, previousHash, nonce, transactions).

## Try it
```
mvn -q compile ; java -cp target/classes com.blocksmith.BlockSmithNode
# open http://localhost:7070/ , then in another terminal:
# curl -XPOST localhost:7070/api/mine -d '{"minerAddress":"Alice"}'  -> watch the block appear
```

## Note on testing
A browser UI is verified by running it; automated coverage here is server-side (mount points + endpoint shape), as planned for this sprint.

## Test plan
- [x] `mvn test` green - 185 tests passing
- [x] `mvn compile` clean

Closes #128
Closes #129