### PR TITLE
Sprint 13c: Wallet + transaction actions in the dashboard

### DIFF
--- a/src/main/resources/public/app.js
+++ b/src/main/resources/public/app.js
@@ -8,11 +8,28 @@
 
 const REFRESH_MS = 4000;
 
-/** Fetches JSON from the node's API, throwing on a non-2xx response. */
-async function fetchJson(path) {
-    const res = await fetch(path);
-    if (!res.ok) throw new Error(path + " -> HTTP " + res.status);
-    return res.json();
+/**
+ * Fetches JSON from the node's API. On a non-2xx response, throws an Error
+ * carrying the API's error envelope message when present, so action handlers
+ * can surface exactly what the node reported.
+ */
+async function fetchJson(path, options) {
+    const res = await fetch(path, options);
+    const data = await res.json().catch(function () { return null; });
+    if (!res.ok) {
+        const message = data && data.error ? data.error : "HTTP " + res.status;
+        throw new Error(message);
+    }
+    return data;
+}
+
+/** POSTs a JSON body and returns the parsed response (throws on API error). */
+function postJson(path, body) {
+    return fetchJson(path, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body || {})
+    });
 }
 
 /** Small DOM helper: element with optional class and text. */
@@ -89,6 +106,69 @@ function setStatus(text, ok) {
     bar.classList.toggle("error", !ok);
 }
 
+// ===== Actions (Sprint 13c) =====
+
+/** Writes an action's outcome into its result line, styled ok/error. */
+function showResult(id, text, ok) {
+    const line = document.getElementById(id);
+    line.textContent = text;
+    line.classList.toggle("error", !ok);
+    line.classList.toggle("ok", ok);
+}
+
+/**
+ * Runs an action, surfacing success or the API error message, and refreshes
+ * the explorer afterwards so any resulting state change is visible at once.
+ */
+async function runAction(resultId, work) {
+    try {
+        const message = await work();
+        showResult(resultId, message, true);
+        refresh();
+    } catch (e) {
+        showResult(resultId, e.message, false);
+    }
+}
+
+function wireActions() {
+    document.getElementById("create-wallet").addEventListener("click", function () {
+        runAction("wallet-result", async function () {
+            const wallet = await postJson("/api/wallet/create");
+            const input = document.getElementById("balance-address");
+            if (!input.value) input.value = wallet.address;
+            return "Created wallet " + wallet.address;
+        });
+    });
+
+    document.getElementById("check-balance").addEventListener("click", function () {
+        runAction("wallet-result", async function () {
+            const address = document.getElementById("balance-address").value.trim();
+            if (!address) throw new Error("Enter an address to look up");
+            const w = await fetchJson("/api/wallet/" + encodeURIComponent(address));
+            return "Balance " + w.balance + " · pending out " + w.pendingOutgoing;
+        });
+    });
+
+    document.getElementById("send-tx").addEventListener("click", function () {
+        runAction("tx-result", async function () {
+            const tx = await postJson("/api/transactions", {
+                sender: document.getElementById("tx-sender").value.trim(),
+                recipient: document.getElementById("tx-recipient").value.trim(),
+                amount: Number(document.getElementById("tx-amount").value)
+            });
+            return "Submitted tx " + shortHash(tx.transactionId);
+        });
+    });
+
+    document.getElementById("mine-block").addEventListener("click", function () {
+        runAction("mine-result", async function () {
+            const address = document.getElementById("mine-address").value.trim();
+            const block = await postJson("/api/mine", { minerAddress: address });
+            return "Mined block #" + block.index + " (" + shortHash(block.hash) + ")";
+        });
+    });
+}
+
 async function refresh() {
     try {
         const [status, peers, blocks] = await Promise.all([
@@ -104,5 +184,6 @@ async function refresh() {
     }
 }
 
+wireActions();
 refresh();
 setInterval(refresh, REFRESH_MS);

--- a/src/main/resources/public/index.html
+++ b/src/main/resources/public/index.html
@@ -19,6 +19,37 @@
             <div id="peers"></div>
         </section>
 
+        <section id="actions">
+            <h2>Actions</h2>
+            <div class="action-grid">
+                <div class="action">
+                    <h3>Wallet</h3>
+                    <button id="create-wallet">Create wallet</button>
+                    <div class="action-row">
+                        <input id="balance-address" type="text" placeholder="address" autocomplete="off">
+                        <button id="check-balance">Check balance</button>
+                    </div>
+                    <p id="wallet-result" class="action-result"></p>
+                </div>
+
+                <div class="action">
+                    <h3>Send transaction</h3>
+                    <input id="tx-sender" type="text" placeholder="sender address" autocomplete="off">
+                    <input id="tx-recipient" type="text" placeholder="recipient address" autocomplete="off">
+                    <input id="tx-amount" type="number" placeholder="amount" min="0" step="any" autocomplete="off">
+                    <button id="send-tx">Submit transaction</button>
+                    <p id="tx-result" class="action-result"></p>
+                </div>
+
+                <div class="action">
+                    <h3>Mine</h3>
+                    <input id="mine-address" type="text" placeholder="miner address" autocomplete="off">
+                    <button id="mine-block">Mine pending block</button>
+                    <p id="mine-result" class="action-result"></p>
+                </div>
+            </div>
+        </section>
+
         <section id="blocks">
             <h2>Blocks</h2>
             <div id="block-list"></div>

--- a/src/main/resources/public/style.css
+++ b/src/main/resources/public/style.css
@@ -141,6 +141,75 @@ section h2 {
     word-break: break-all;
 }
 
+/* Actions (Sprint 13c) */
+.action-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 1rem;
+}
+
+.action {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 1rem;
+}
+
+.action h3 {
+    margin: 0;
+    font-size: 0.95rem;
+    color: var(--text);
+}
+
+.action-row {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.action-row input { flex: 1; min-width: 0; }
+
+.action input {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    color: var(--text);
+    padding: 0.45rem 0.6rem;
+    font-size: 0.85rem;
+    font-family: ui-monospace, Consolas, monospace;
+}
+
+.action input:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+
+.action button {
+    background: var(--accent);
+    color: #1a1200;
+    border: none;
+    border-radius: 4px;
+    padding: 0.45rem 0.8rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.action button:hover { filter: brightness(1.08); }
+
+.action-result {
+    margin: 0.25rem 0 0;
+    font-size: 0.8rem;
+    font-family: ui-monospace, Consolas, monospace;
+    word-break: break-all;
+    min-height: 1rem;
+}
+
+.action-result.ok { color: var(--accent); }
+.action-result.error { color: #ff6b6b; }
+
 footer {
     padding: 1.5rem 2rem;
     border-top: 1px solid var(--border);

--- a/src/test/java/com/blocksmith/api/ApiDashboardActionsTest.java
+++ b/src/test/java/com/blocksmith/api/ApiDashboardActionsTest.java
@@ -1,0 +1,121 @@
+package com.blocksmith.api;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.blocksmith.network.Node;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Server-side glue for the Milestone 13c dashboard actions.
+ *
+ * The browser UI is verified by running it; here we drive the SAME endpoint
+ * chain the dashboard buttons hit - create wallet, mine, check balance, submit
+ * a transaction, mine again - end to end, and confirm value moves as a user
+ * would expect from the page. The individual endpoints already have focused
+ * Sprint 12 tests; this checks they compose correctly for the UI flow.
+ */
+@DisplayName("API Dashboard Actions Tests")
+class ApiDashboardActionsTest {
+
+    private static final int API_PORT_BASE = 17500;
+    private static final int P2P_PORT_BASE = 19000;
+    private static final double MINING_REWARD = 50.0;
+    private static int counter = 0;
+
+    private Node node;
+    private ApiServer api;
+    private int apiPort;
+    private final HttpClient client = HttpClient.newHttpClient();
+
+    @BeforeEach
+    void setUp() {
+        int offset = counter++;
+        apiPort = API_PORT_BASE + offset;
+        node = new Node(P2P_PORT_BASE + offset);
+        api = new ApiServer(node, apiPort);
+        api.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (api != null) api.stop();
+        if (node != null) node.stop();
+    }
+
+    private HttpResponse<String> get(String path) throws Exception {
+        return client.send(
+                HttpRequest.newBuilder()
+                        .uri(URI.create("http://localhost:" + apiPort + path))
+                        .GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    private HttpResponse<String> post(String path, String body) throws Exception {
+        return client.send(
+                HttpRequest.newBuilder()
+                        .uri(URI.create("http://localhost:" + apiPort + path))
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString(body))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    private static JsonObject json(HttpResponse<String> res) {
+        return JsonParser.parseString(res.body()).getAsJsonObject();
+    }
+
+    @Test
+    @DisplayName("Dashboard action chain moves value end to end")
+    void dashboardActionEndpoints_behaveAsExpected() throws Exception {
+        // Create wallet button -> POST /api/wallet/create.
+        HttpResponse<String> created = post("/api/wallet/create", "{}");
+        assertEquals(201, created.statusCode());
+        String miner = json(created).get("address").getAsString();
+        assertNotNull(miner);
+
+        // Mine button -> POST /api/mine, giving the miner a coinbase reward.
+        assertEquals(201, post("/api/mine", "{\"minerAddress\":\"" + miner + "\"}").statusCode());
+
+        // Balance lookup -> GET /api/wallet/{address}.
+        JsonObject balance = json(get("/api/wallet/" + miner));
+        assertEquals(MINING_REWARD, balance.get("balance").getAsDouble(), 0.0001,
+                "Miner should hold the coinbase reward after mining");
+
+        // Send transaction form -> POST /api/transactions (spend part of the reward).
+        String recipient = "recipient-address";
+        String txBody = "{\"sender\":\"" + miner + "\",\"recipient\":\""
+                + recipient + "\",\"amount\":10}";
+        HttpResponse<String> txRes = post("/api/transactions", txBody);
+        assertEquals(201, txRes.statusCode());
+        assertTrue(json(txRes).has("transactionId"), "Response should echo the transaction id");
+
+        // The transaction is pending until mined.
+        assertEquals(0.0, json(get("/api/wallet/" + recipient)).get("balance").getAsDouble(), 0.0001);
+        assertEquals(10.0, json(get("/api/wallet/" + miner)).get("pendingOutgoing").getAsDouble(), 0.0001);
+
+        // Mine again -> the pending transaction confirms.
+        assertEquals(201, post("/api/mine", "{\"minerAddress\":\"" + miner + "\"}").statusCode());
+        assertEquals(10.0, json(get("/api/wallet/" + recipient)).get("balance").getAsDouble(), 0.0001,
+                "Recipient should receive the transferred amount once mined");
+    }
+
+    @Test
+    @DisplayName("Rejected action returns an error envelope the UI can surface")
+    void rejectedAction_returnsErrorEnvelope() throws Exception {
+        // Submit-transaction form with a missing field -> 400 + {"error": ...}.
+        HttpResponse<String> res = post("/api/transactions", "{\"sender\":\"a\",\"amount\":5}");
+        assertEquals(400, res.statusCode());
+        assertTrue(json(res).has("error"), "Error responses must carry an 'error' message for the UI");
+    }
+}


### PR DESCRIPTION
Makes the explorer dashboard interactive by wiring UI controls to the Sprint 12 write endpoints. The dashboard now drives the same node a peer would, so an action taken here propagates over P2P.

## What's new
- **Wallet** — Create-wallet button (`POST /api/wallet/create`) and balance lookup (`GET /api/wallet/{address}`, confirmed balance + pending outgoing). Creating a wallet pre-fills the balance field.
- **Send transaction** — sender/recipient/amount form (`POST /api/transactions`), echoes the new tx id.
- **Mine** — miner-address button (`POST /api/mine`), then the chain refreshes.
- **Error surfacing** — `fetchJson` now reads the API's `{"error": ...}` envelope on non-2xx and shows the node's message inline; every action refreshes the explorer on success.

All values written with `textContent` (no `innerHTML`), consistent with 13b.

## Tests
`ApiDashboardActionsTest` (2, server-side glue):
- `dashboardActionEndpoints_behaveAsExpected` — drives the full UI chain (create wallet -> mine -> balance -> send -> mine) and asserts value moves end to end.
- `rejectedAction_returnsErrorEnvelope` — a bad transaction returns 400 with an `error` message the UI can surface.

**Full suite: 187 passing** (was 185).

## Try it
```
mvn -q compile
java -cp target/classes com.blocksmith.BlockSmithNode
# open http://localhost:7070/ -> create wallet, mine to it, send, mine again
```

Closes #131, #132.