### PR TITLE
docs: Sprint 13 complete (Web Dashboard)

### DIFF
--- a/.ai/ONBOARDING.md
+++ b/.ai/ONBOARDING.md
@@ -39,9 +39,9 @@
 | **Test Framework** | JUnit 5 |
 | **Serialization** | Gson 2.10.1 |
 | **Current Phase** | Phase 3: API & Interface — In Progress |
-| **Current Sprint** | Sprint 12 (REST API) — Complete |
-| **Current Milestone** | 12c Complete; next: Sprint 13 (Web Dashboard) |
-| **Total Tests** | 180 (all passing) |
+| **Current Sprint** | Sprint 13 (Web Dashboard) — Complete |
+| **Current Milestone** | 13c Complete; next: Sprint 14 (Smart Contracts) |
+| **Total Tests** | 187 (all passing) |
 | **Main Branch** | `master` |
 
 ---
@@ -112,10 +112,12 @@ BlockSmith/
 │           ├── GetMempoolMessage.java # ✅ Complete (Sprint 11c)
 │           └── MempoolMessage.java   # ✅ Complete (Sprint 11c)
 │
-│   └── api/                          # REST API (Sprint 12)
-│       └── ApiServer.java            # ✅ Complete (Javalin: blocks, tx, mine, wallet, network)
+│   ├── api/                          # REST API (Sprint 12)
+│   │   └── ApiServer.java            # ✅ Complete (Javalin: blocks, tx, mine, wallet, network + static hosting)
+│   └── BlockSmithNode.java           # ✅ Complete (runnable node: P2P + API + dashboard, Sprint 13a)
 │
-├── src/test/java/com/blocksmith/     # 180 unit tests
+├── src/main/resources/public/        # Web dashboard (Sprint 13): index.html, app.js, style.css
+├── src/test/java/com/blocksmith/     # 187 unit tests
 ├── pom.xml                           # Maven configuration (Gson, JUnit, Javalin)
 └── README.md                         # Public documentation
 ```
@@ -147,12 +149,14 @@ BlockSmith/
 
 **Sprint 12: REST API** — Javalin `ApiServer` on port 7070: block read endpoints + network status, transaction submit/lookup + mining (broadcast on write), wallet balance/create + peers, JSON error envelope (400/404/500).
 
+**Sprint 13: Web Dashboard** — `BlockSmithNode` runnable entry point (Node + ApiServer in one process), Javalin static hosting of a vanilla HTML/JS/CSS dashboard at `/`: explorer view (blocks + network, 4s polling) and actions (create wallet, balance lookup, send tx, mine) with API errors surfaced inline. Run: `java -cp target/classes com.blocksmith.BlockSmithNode` → `http://localhost:7070/`.
+
 ---
 
 ## What's NOT Implemented Yet
 
-### Phase 3 remaining (Sprints 13-15) ← NEXT
-- Web dashboard (Sprint 13), basic smart contracts (Sprint 14), multi-sig wallets (Sprint 15)
+### Phase 3 remaining (Sprints 14-15) ← NEXT
+- Basic smart contracts (Sprint 14), multi-sig wallets (Sprint 15)
 
 ### Phase 4: Production Features (Sprints 16-19)
 - Database persistence, dynamic difficulty, block limits, fee market
@@ -240,7 +244,10 @@ mvn compile -q; java -cp target/classes com.blocksmith.BlockSmithDemo
 | ApiReadEndpointsTest | 5 | REST block/status read endpoints (Sprint 12a) |
 | ApiTransactionEndpointsTest | 5 | REST transaction submit/lookup + mining (Sprint 12b) |
 | ApiWalletNetworkEndpointsTest | 4 | REST wallet/network endpoints + JSON errors (Sprint 12c) |
-| **Total** | **180** | All passing ✅ |
+| ApiStaticHostingTest | 3 | Dashboard shell + static assets alongside the API (Sprint 13a) |
+| ApiExplorerTest | 2 | Explorer mount points + block JSON shape (Sprint 13b) |
+| ApiDashboardActionsTest | 2 | Dashboard action chain end to end (Sprint 13c) |
+| **Total** | **187** | All passing ✅ |
 
 ---
 
@@ -251,7 +258,7 @@ mvn compile -q; java -cp target/classes com.blocksmith.BlockSmithDemo
 - **Doc branches**: `docs/{description}` (e.g., `docs/sprint11-complete`)
 - **Commits**: One per issue, format: `feat(scope): description #NN` — never add `Co-Authored-By`
 - **PRs**: created with `gh`, include `Closes #NN` lines, ff-only merge to sync local master
-- **Latest**: Sprint 12 complete (REST API, PR #121); Phase 3 in progress
+- **Latest**: Sprint 13 complete (Web Dashboard, PR #133); Phase 3 in progress
 
 ---
 
@@ -263,9 +270,9 @@ mvn compile -q; java -cp target/classes com.blocksmith.BlockSmithDemo
 | `CONVENTIONS.md` | Need full code style rules, THEORY comment format, test conventions |
 | `STATUS.md` | Need exact current status, implementation table, feature checklist |
 | `roadmap.md` | Need full project phases and timeline |
-| `sprints/sprint12/sprint-plan.md` | Most recent sprint's milestones, issues, acceptance criteria |
-| `sprints/sprint12/sprint-log.md` | What was completed in the latest sprint |
+| `sprints/sprint13/sprint-plan.md` | Most recent sprint's milestones, issues, acceptance criteria |
+| `sprints/sprint13/sprint-log.md` | What was completed in the latest sprint |
 
 ---
 
-*Last updated: 2026-07-02 | Sprint 12 Complete (Milestone 12c) — Phase 3 In Progress*
+*Last updated: 2026-07-03 | Sprint 13 Complete (Milestone 13c) — Phase 3 In Progress*

--- a/.ai/STATUS.md
+++ b/.ai/STATUS.md
@@ -9,9 +9,9 @@
 | Field | Value |
 |-------|-------|
 | **Phase** | 3 - API & Interface - In Progress |
-| **Current Sprint** | 12 (REST API) - Complete |
-| **Current Milestone** | 12c Complete (Wallet + network endpoints) |
-| **Status** | Sprint 12 complete (12a-12c), next: Sprint 13 (Web Dashboard) |
+| **Current Sprint** | 13 (Web Dashboard) - Complete |
+| **Current Milestone** | 13c Complete (Wallet + transaction actions) |
+| **Status** | Sprint 13 complete (13a-13c), next: Sprint 14 (Smart Contracts) |
 
 ---
 
@@ -46,10 +46,10 @@ Phase 2: Network Layer       [███████████████] 100
 ├── Sprint 10: Broadcasting  ✅ COMPLETE (10a ✅, 10b ✅, 10c ✅, 10d ✅)
 └── Sprint 11: Mempool Sync  ✅ COMPLETE (11a ✅, 11b ✅, 11c ✅)
 
-Phase 3: API & Interface     [████░░░░░░░░░░░] 25% ← CURRENT
+Phase 3: API & Interface     [████████░░░░░░░] 50% ← CURRENT
 ├── Sprint 12: REST API      ✅ COMPLETE (12a ✅, 12b ✅, 12c ✅)
-├── Sprint 13: Web Dashboard ⬜ ← NEXT
-├── Sprint 14: Smart Contracts ⬜
+├── Sprint 13: Web Dashboard ✅ COMPLETE (13a ✅, 13b ✅, 13c ✅)
+├── Sprint 14: Smart Contracts ⬜ ← NEXT
 └── Sprint 15: Multi-sig Wallets ⬜
 ```
 
@@ -84,7 +84,10 @@ Phase 3: API & Interface     [████░░░░░░░░░░░] 25%
 | ApiReadEndpointsTest | 5 | ✅ |
 | ApiTransactionEndpointsTest | 5 | ✅ |
 | ApiWalletNetworkEndpointsTest | 4 | ✅ |
-| **Total** | **180** | ✅ |
+| ApiStaticHostingTest | 3 | ✅ |
+| ApiExplorerTest | 2 | ✅ |
+| ApiDashboardActionsTest | 2 | ✅ |
+| **Total** | **187** | ✅ |
 
 Last test run: `mvn test` - All passing
 
@@ -131,13 +134,22 @@ Last test run: `mvn test` - All passing
 
 | Class | Status | Lines | Notes |
 |-------|--------|-------|-------|
-| ApiServer.java | ✅ Complete | ~300 | Javalin REST API: blocks, transactions, mining, wallet, network, JSON errors (Sprint 12) |
+| ApiServer.java | ✅ Complete | ~300 | Javalin REST API: blocks, transactions, mining, wallet, network, JSON errors (Sprint 12) + static dashboard hosting (Sprint 13a) |
 
-### Demo
+### Web Dashboard (`src/main/resources/public`)
+
+| File | Status | Notes |
+|------|--------|-------|
+| index.html | ✅ Complete | Dashboard shell: network, actions, blocks sections (Sprint 13) |
+| app.js | ✅ Complete | Vanilla JS explorer + actions, 4s polling, textContent-only rendering (Sprint 13b/13c) |
+| style.css | ✅ Complete | Dark theme, stat tiles, block cards, action forms (Sprint 13) |
+
+### Entry Points
 
 | Class | Status | Notes |
 |-------|--------|-------|
-| BlockSmithDemo.java | ✅ Complete | Mining + Transactions |
+| BlockSmithNode.java | ✅ Complete | Runnable node: P2P Node + ApiServer + dashboard in one process (Sprint 13a) |
+| BlockSmithDemo.java | ✅ Complete | Mining + Transactions demo |
 
 ---
 
@@ -199,6 +211,11 @@ Last test run: `mvn test` - All passing
 - [x] Transaction submit/lookup + mining endpoints, broadcast on write (Sprint 12b)
 - [x] Wallet balance/create + peers endpoints (Sprint 12c)
 - [x] Consistent JSON error envelope (400/404/500) (Sprint 12c)
+- [x] Runnable node entry point: Node + ApiServer in one process (Sprint 13a)
+- [x] Javalin static hosting for the dashboard at `/` (Sprint 13a)
+- [x] Explorer view: blocks + network panel with polling refresh (Sprint 13b)
+- [x] Dashboard actions: create wallet, balance lookup, send tx, mine (Sprint 13c)
+- [x] API error envelopes surfaced inline in the UI (Sprint 13c)
 
 ---
 
@@ -207,7 +224,7 @@ Last test run: `mvn test` - All passing
 | Item | Value |
 |------|-------|
 | **Current Branch** | `master` |
-| **Last Commit** | Sprint 12 complete (REST API merged, PR #121) |
+| **Last Commit** | Sprint 13 complete (dashboard actions merged, PR #133) |
 | **Tag** | `v1.0.0` (Phase 1) |
 | **Main Branch** | `master` |
 
@@ -221,20 +238,19 @@ _None currently._
 
 ## 📝 Notes for Next Session
 
-1. **Sprint 12 COMPLETE** - REST API
-   - All milestones 12a, 12b, 12c merged to master
-   - Javalin `ApiServer` on port 7070: blocks, transactions, mining, wallet,
-     network endpoints + JSON error handling
-   - Writes over HTTP (submit tx, mine) propagate to peers via the existing
-     broadcast paths
-   - First dependency beyond Gson/JUnit: `io.javalin:javalin` 6.3.0
+1. **Sprint 13 COMPLETE** - Web Dashboard
+   - All milestones 13a, 13b, 13c merged to master
+   - `BlockSmithNode` boots Node + ApiServer in one process; dashboard served
+     at `http://localhost:7070/` from `src/main/resources/public`
+   - Explorer (blocks + network, 4s polling) and actions (create wallet,
+     balance, send tx, mine) drive the Sprint 12 endpoints; API errors surface
+     inline in the UI
+   - Vanilla HTML/JS/CSS, no build step; values rendered with `textContent`
 
-2. **Phase 3 IN PROGRESS** - API & Interface (Sprint 12 done, 25%)
+2. **Phase 3 IN PROGRESS** - API & Interface (Sprints 12-13 done, 50%)
 
-3. **Next: Sprint 13** - Web Dashboard
-   - HTML/JS frontend over the REST API (chain view, wallet UI, live updates)
-   - `ApiServer` is not yet wired into `BlockSmithDemo` / a runnable main - a
-     small entry point that starts a Node + ApiServer would help the dashboard
+3. **Next: Sprint 14** - Smart Contracts
+   - Not yet planned; scope and milestones TBD in sprint planning
 
 4. **Deferred / future work**
    - Gossip auto-connect to DISCOVERED peers (needs MAX_PEERS guarding)
@@ -243,7 +259,10 @@ _None currently._
      yet pull the peer's mempool
    - API transactions are unsigned (educational); signature-carrying submission
      would need public-key + signature fields in the request body
+   - WebSocket push for the dashboard (currently 4s polling)
+   - `pom.xml` exec/jar main class still points at `BlockSmithDemo`, not
+     `BlockSmithNode`
 
 ---
 
-*Last updated: 2026-07-02 | Sprint 12 Complete (Milestone 12c) - Phase 3 In Progress*
+*Last updated: 2026-07-03 | Sprint 13 Complete (Milestone 13c) - Phase 3 In Progress*

--- a/.ai/roadmap.md
+++ b/.ai/roadmap.md
@@ -28,9 +28,9 @@ Transform BlockSmith from an educational blockchain into a **fully functional di
 │  ├── Block Broadcasting                          ✅ Sprint 10       │
 │  └── Mempool Synchronization                     ✅ Sprint 11       │
 │                                                                     │
-│  PHASE 3: API & Interface (Sprint 12-15)        ████░░░░░░░░ 25% ←NOW│
+│  PHASE 3: API & Interface (Sprint 12-15)        ██████░░░░░░ 50% ←NOW│
 │  ├── REST API                                    ✅ Sprint 12       │
-│  ├── Web Dashboard                               ⬜ Sprint 13       │
+│  ├── Web Dashboard                               ✅ Sprint 13       │
 │  ├── Basic Smart Contracts                       ⬜ Sprint 14       │
 │  └── Multi-signature Wallets                     ⬜ Sprint 15       │
 │                                                                     │
@@ -98,15 +98,15 @@ com.blocksmith.network/
 
 ---
 
-## 🖥️ Phase 3: API & Interface 🔄 In Progress (25%)
+## 🖥️ Phase 3: API & Interface 🔄 In Progress (50%)
 
 **Goal:** Add REST API and web dashboard for easy interaction.
 
 | Sprint | Title | Key Deliverables | Status |
 |--------|-------|------------------|--------|
 | 12 | REST API | Javalin HTTP endpoints (blocks, tx, mine, wallet, network), JSON responses | ✅ Complete |
-| 13 | Web Dashboard | HTML/JS frontend, real-time updates, wallet UI | ⬜ Next |
-| 14 | Smart Contracts | Script interpreter, basic conditions, contract storage | ⬜ Planned |
+| 13 | Web Dashboard | Runnable node entry point, explorer view (blocks + network), wallet/tx/mine actions, polling refresh | ✅ Complete |
+| 14 | Smart Contracts | Script interpreter, basic conditions, contract storage | ⬜ Next |
 | 15 | Multi-sig Wallets | M-of-N signatures, threshold signing | ⬜ Planned |
 
 ### API Endpoints (Sprint 12)
@@ -124,9 +124,9 @@ GET  /api/network/status      # Network status
 ```
 
 ### Technologies
-- Javalin or Spark Java (lightweight HTTP server)
-- HTML5 + Vanilla JS (or htmx for simplicity)
-- WebSocket for real-time updates
+- Javalin 6.3.0 (lightweight HTTP server, embedded Jetty) ✅
+- HTML5 + Vanilla JS, no build step ✅
+- Polling refresh (4s); WebSocket push is a possible later enhancement
 
 ---
 

--- a/.ai/sprints/sprint13/sprint-log.md
+++ b/.ai/sprints/sprint13/sprint-log.md
@@ -4,33 +4,63 @@
 
 | Event | Date |
 |-------|------|
-| **Sprint Start** | TBD |
-| **Sprint End** | TBD |
+| **Sprint Start** | 2026-07-02 |
+| **Sprint End** | 2026-07-03 |
 
 ---
 
-## Milestone 13a: Runnable node entry point + static hosting - Pending
+## Milestone 13a: Runnable node entry point + static hosting - Complete ✅
+
+**Issues:** #124 (entry point), #125 (static hosting), #126 (tests) | **PR:** #127
+
+- `BlockSmithNode` main: boots a P2P `Node` and an `ApiServer` in one process,
+  ports overridable via args, clean shutdown hook
+- Javalin static hosting from `src/main/resources/public` (classpath); `/`
+  serves the dashboard shell, `/api/*` keeps routing to the API
+- `ApiStaticHostingTest` (3 tests): root shell, static asset, API coexistence
+
+## Milestone 13b: Explorer view (blocks + network) - Complete ✅
+
+**Issues:** #128 (explorer), #129 (tests) | **PR:** #130
+
+- `app.js`: polls `/api/network/status`, `/api/network/peers`, `/api/blocks`
+  every 4s; renders stat tiles, peer list, block cards (newest first, tip
+  highlighted); all values via `textContent` (never `innerHTML`)
+- `index.html` mount points + dark-theme `style.css`
+- `ApiExplorerTest` (2 tests): mount points served, block JSON shape matches
+  what the UI reads
+
+## Milestone 13c: Wallet + transaction actions - Complete ✅
+
+**Issues:** #131 (actions), #132 (tests) | **PR:** #133
+
+- Actions section: create-wallet button, balance lookup, send-transaction
+  form, mine button - wired to the Sprint 12 write endpoints
+- `fetchJson` reads the API `{"error": ...}` envelope on non-2xx and surfaces
+  the node's message inline; every action refreshes the explorer on success
+- `ApiDashboardActionsTest` (2 tests): full action chain moves value end to
+  end; rejected action returns an error envelope
 
 ---
 
-## Milestone 13b: Explorer view (blocks + network) - Pending
+## Results
 
----
-
-## Milestone 13c: Wallet + transaction actions - Pending
-
----
+- **Tests:** 180 -> 187 (+3 static hosting, +2 explorer, +2 dashboard actions)
+- The project is now runnable as a single process with a browser UI:
+  `java -cp target/classes com.blocksmith.BlockSmithNode` -> `http://localhost:7070/`
+- An action taken in the browser propagates to peers over P2P via the
+  existing broadcast paths
 
 ## Notes
 
 - Second sprint of Phase 3 (API & Interface); Sprint 12 delivered the REST API
 - Approach: vanilla HTML/JS/CSS, no build step, served by Javalin static hosting;
   polling refresh (WebSocket push is a possible later enhancement)
-- Closes the "no runnable main" gap noted after Sprint 12: 13a boots Node +
+- Closed the "no runnable main" gap noted after Sprint 12: 13a boots Node +
   ApiServer as a single process
 - Testing reality: the browser UI is verified by running it, so automated tests
   focus on the server side (static serving + the endpoints the UI consumes)
 
 ---
 
-*Created: 2026-07-02*
+*Created: 2026-07-02 | Completed: 2026-07-03*

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ BlockSmith is a comprehensive blockchain project that goes beyond tutorials - im
 
 [![Java](https://img.shields.io/badge/Java-20+-orange.svg)](https://openjdk.org/)
 [![Maven](https://img.shields.io/badge/Maven-3.9+-blue.svg)](https://maven.apache.org/)
-[![Tests](https://img.shields.io/badge/Tests-180%20passing-brightgreen.svg)](#)
+[![Tests](https://img.shields.io/badge/Tests-187%20passing-brightgreen.svg)](#)
 [![Phase](https://img.shields.io/badge/Phase%202-In%20Progress-yellow.svg)](#)
 [![Version](https://img.shields.io/badge/Version-1.0.0-blue.svg)](#)
 
@@ -49,12 +49,16 @@ BlockSmith is a comprehensive blockchain project that goes beyond tutorials - im
   - ✅ Prune confirmed transactions from the mempool (Sprint 11b)
   - ✅ Mempool sync on connect (GET_MEMPOOL/MEMPOOL) (Sprint 11c)
 
-### Phase 3: API & Interface 🔄 In Progress (25%)
+### Phase 3: API & Interface 🔄 In Progress (50%)
 - ✅ REST API for blockchain interaction (Sprint 12)
   - ✅ Javalin server + block read endpoints (Sprint 12a)
   - ✅ Transaction submit/lookup + mining endpoints (Sprint 12b)
   - ✅ Wallet + network endpoints + JSON errors (Sprint 12c)
-- 🔜 Web dashboard for monitoring (Sprint 13)
+- ✅ Web dashboard (Sprint 13)
+  - ✅ Runnable node entry point + static hosting (Sprint 13a)
+  - ✅ Explorer view: blocks + network, polling refresh (Sprint 13b)
+  - ✅ Wallet, transaction, and mine actions in the UI (Sprint 13c)
+- 🔜 Basic smart contracts (Sprint 14)
 - 🔜 Basic smart contract support (Sprint 14)
 - 🔜 Multi-signature wallets (Sprint 15)
 
@@ -198,9 +202,16 @@ Average attempts: ~16^difficulty (~65,536 for difficulty 4)
 mvn clean compile
 ```
 
-### Run all tests (180 tests)
+### Run all tests (187 tests)
 ```bash
 mvn test
+```
+
+### Run a node with the web dashboard
+```bash
+mvn -q compile
+java -cp target/classes com.blocksmith.BlockSmithNode
+# open http://localhost:7070/
 ```
 
 ### Run the demo
@@ -253,8 +264,12 @@ BlockSmith/
 │   │   ├── PeerInfo.java      # Peer metadata tracking
 │   │   ├── PeerManager.java   # Peer registry with MAX_PEERS enforcement
 │   │   └── messages/           # Concrete message classes (incl. GetPeers/Peers)
+│   ├── api/
+│   │   └── ApiServer.java      # Javalin REST API + static dashboard hosting
+│   ├── BlockSmithNode.java     # Runnable node (P2P + API + dashboard)
 │   └── BlockSmithDemo.java     # Main demo application
-├── src/test/java/              # 180 unit tests
+├── src/main/resources/public/  # Web dashboard (index.html, app.js, style.css)
+├── src/test/java/              # 187 unit tests
 ├── data/                       # Blockchain persistence (JSON)
 ├── pom.xml                     # Maven configuration
 └── README.md
@@ -291,7 +306,10 @@ BlockSmith/
 | ApiReadEndpointsTest | 5 | REST block/status read endpoints |
 | ApiTransactionEndpointsTest | 5 | REST transaction submit/lookup + mining |
 | ApiWalletNetworkEndpointsTest | 4 | REST wallet/network endpoints + JSON errors |
-| **Total** | **180** | All passing ✅ |
+| ApiStaticHostingTest | 3 | Dashboard shell + static assets alongside the API |
+| ApiExplorerTest | 2 | Explorer mount points + block JSON shape |
+| ApiDashboardActionsTest | 2 | Dashboard action chain end to end |
+| **Total** | **187** | All passing ✅ |
 
 ---
 
@@ -345,11 +363,11 @@ BlockSmith/
 | Sprint 10 | Block Broadcasting | ✅ Complete (10a, 10b, 10c, 10d) |
 | Sprint 11 | Mempool Sync | ✅ Complete (11a, 11b, 11c) |
 
-### Phase 3: API & Interface 🔄 In Progress (25%)
+### Phase 3: API & Interface 🔄 In Progress (50%)
 | Sprint | Title | Status |
 |--------|-------|--------|
 | Sprint 12 | REST API | ✅ Complete (12a, 12b, 12c) |
-| Sprint 13 | Web Dashboard | ⬜ Planned |
+| Sprint 13 | Web Dashboard | ✅ Complete (13a, 13b, 13c) |
 | Sprint 14 | Smart Contracts | ⬜ Planned |
 | Sprint 15 | Multi-sig Wallets | ⬜ Planned |
 
@@ -380,4 +398,4 @@ This project is for educational purposes.
 
 ---
 
-*Last updated: 2026-07-02 | Phase 3 In Progress (Sprint 12 - REST API Complete)*
+*Last updated: 2026-07-03 | Phase 3 In Progress (Sprint 13 - Web Dashboard Complete)*


### PR DESCRIPTION
Brings all project docs in line with Sprint 13 (Web Dashboard) being complete.

## Updated
- **`.ai/STATUS.md`** — Sprint 13 complete (13a-13c), Phase 3 at 50%, test table -> **187**, new dashboard/entry-point sections, notes for next session (Sprint 14: Smart Contracts)
- **`README.md`** — badge + test table -> 187, Phase 3 progress, dashboard run instructions, project tree (api/, BlockSmithNode, resources/public)
- **`.ai/roadmap.md`** — Phase 3 at 50%, Sprint 13 ✅, technologies section reflects the actual stack (Javalin 6.3.0, vanilla JS, polling)
- **`.ai/ONBOARDING.md`** — quick-ref table, project tree, Sprint 13 summary with run command, test table -> 187, deep-dive links -> sprint13
- **`.ai/sprints/sprint13/sprint-log.md`** — full log: 13a (#124-#126, PR #127), 13b (#128/#129, PR #130), 13c (#131/#132, PR #133), results + notes

No code changes.