### PR TITLE
Sprint 14b: Contracts on the chain (deploy/claim)

### DIFF
--- a/src/main/java/com/blocksmith/contract/Contract.java
+++ b/src/main/java/com/blocksmith/contract/Contract.java
@@ -1,0 +1,93 @@
+package com.blocksmith.contract;
+
+import com.blocksmith.util.BlockchainConfig;
+
+/**
+ * THEORY: A contract is funds locked behind a script instead of an owner.
+ *
+ * A plain transaction gives money to an ADDRESS; a contract gives money to a
+ * CONDITION. The locking script is the condition; the locked amount belongs
+ * to nobody until someone presents unlocking data that makes the script
+ * evaluate true, at which point the chain credits them.
+ *
+ * DERIVED STATE:
+ * A Contract object is not gossiped or stored on its own - it is REBUILT from
+ * the chain. A deploy transaction (recipient = CONTRACT:<id>, carrying the
+ * locking script) opens it; a claim transaction (sender = CONTRACT:<id>)
+ * closes it. Because every node replays the same blocks, every node derives
+ * the same contract registry - the same trick the balance model uses.
+ *
+ * TWO FLAGSHIP CONDITIONS:
+ * - Hashlock: "SHA256 PUSH <hash> EQUAL"    - reveal the preimage to claim
+ * - Timelock: "PUSH <height> CHECKLOCKTIME" - claimable once the chain is tall enough
+ */
+public class Contract {
+
+    private final String contractId;
+    private final String funder;
+    private final String lockingScript;
+    private final double amount;
+    private final long creationHeight;
+    private ContractStatus status;
+    private String claimer;
+
+    public Contract(String contractId, String funder, String lockingScript,
+                    double amount, long creationHeight) {
+        this.contractId = contractId;
+        this.funder = funder;
+        this.lockingScript = lockingScript;
+        this.amount = amount;
+        this.creationHeight = creationHeight;
+        this.status = ContractStatus.OPEN;
+    }
+
+    /** Marks the contract spent by {@code claimer}. */
+    public void markClaimed(String claimer) {
+        this.status = ContractStatus.CLAIMED;
+        this.claimer = claimer;
+    }
+
+    /** The chain address holding this contract's locked funds. */
+    public String getAddress() {
+        return BlockchainConfig.CONTRACT_ADDRESS_PREFIX + contractId;
+    }
+
+    // ===== GETTERS =====
+
+    public String getContractId() {
+        return contractId;
+    }
+
+    public String getFunder() {
+        return funder;
+    }
+
+    public String getLockingScript() {
+        return lockingScript;
+    }
+
+    public double getAmount() {
+        return amount;
+    }
+
+    public long getCreationHeight() {
+        return creationHeight;
+    }
+
+    public ContractStatus getStatus() {
+        return status;
+    }
+
+    public String getClaimer() {
+        return claimer;
+    }
+
+    @Override
+    public String toString() {
+        return String.format(java.util.Locale.US, "Contract{id=%s..., %s locked %.2f, %s}",
+            contractId.substring(0, Math.min(8, contractId.length())),
+            funder,
+            amount,
+            status);
+    }
+}

--- a/src/main/java/com/blocksmith/contract/ContractStatus.java
+++ b/src/main/java/com/blocksmith/contract/ContractStatus.java
@@ -1,0 +1,12 @@
+package com.blocksmith.contract;
+
+/**
+ * Lifecycle of a contract's locked funds.
+ *
+ * OPEN    - funds are locked; anyone who satisfies the locking script can claim
+ * CLAIMED - funds have been released to a claimer; the contract is spent
+ */
+public enum ContractStatus {
+    OPEN,
+    CLAIMED
+}

--- a/src/main/java/com/blocksmith/core/Blockchain.java
+++ b/src/main/java/com/blocksmith/core/Blockchain.java
@@ -1,6 +1,10 @@
 package com.blocksmith.core;
 
+import com.blocksmith.contract.Contract;
+import com.blocksmith.contract.ContractStatus;
+import com.blocksmith.contract.ScriptVM;
 import com.blocksmith.util.BlockchainConfig;
+import com.blocksmith.util.HashUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -39,6 +43,21 @@ public class Blockchain {
 
     private final List<Block> chain;
     private final List<Transaction> pendingTransactions;
+
+    /**
+     * THEORY: CONTRACT REGISTRY (Sprint 14)
+     *
+     * Contract state is DERIVED from the chain, never stored independently:
+     * every appended block is scanned for deploy transactions (recipient =
+     * CONTRACT:<id>, carrying a locking script) and claim transactions
+     * (sender = CONTRACT:<id>). Since all nodes replay the same blocks, all
+     * nodes derive the same registry - like balances, contract state is a
+     * view over the chain.
+     */
+    private final Map<String, Contract> contracts = new LinkedHashMap<>();
+
+    /** Evaluates contract scripts; never throws (consensus safety). */
+    private final ScriptVM scriptVM = new ScriptVM();
 
     /**
      * Largest number of orphan blocks held at once. Caps memory if a peer
@@ -152,6 +171,7 @@ public class Blockchain {
                 && block.getPreviousHash().equals(tip.getHash())) {
             chain.add(block);
             removeConfirmed(block);
+            registerContracts(block);
             attachOrphans();
             return true;
         }
@@ -191,6 +211,7 @@ public class Blockchain {
             if (child.getIndex() == tip.getIndex() + 1 && isWellFormed(child)) {
                 chain.add(child);
                 removeConfirmed(child);
+                registerContracts(child);
             } else {
                 break; // stale/ill-fitting orphan: drop and stop
             }
@@ -254,6 +275,20 @@ public class Blockchain {
         // Reject COINBASE transactions (only mining creates these)
         if (transaction.getSender().equals(BlockchainConfig.COINBASE_ADDRESS)) {
             System.out.println("Transaction rejected: Cannot manually create COINBASE transactions");
+            return false;
+        }
+
+        // Contract rules (Sprint 14). A transfer TO a contract address must
+        // carry a locking script (otherwise the funds would be burned); a
+        // transfer FROM one is a claim and must satisfy the contract's script.
+        if (transaction.getRecipient().startsWith(BlockchainConfig.CONTRACT_ADDRESS_PREFIX)
+                && (transaction.getLockingScript() == null
+                    || transaction.getLockingScript().isBlank())) {
+            System.out.println("Transaction rejected: Contract deploy requires a locking script");
+            return false;
+        }
+        if (transaction.getSender().startsWith(BlockchainConfig.CONTRACT_ADDRESS_PREFIX)
+                && !isValidClaim(transaction)) {
             return false;
         }
 
@@ -348,6 +383,7 @@ public class Blockchain {
 
         // Add block to chain
         chain.add(newBlock);
+        registerContracts(newBlock);
 
         // Clear pending transactions (they're now in a block)
         pendingTransactions.clear();
@@ -390,9 +426,152 @@ public class Blockchain {
         return balance;
     }
 
+    // ===== CONTRACTS (Sprint 14) =====
+
+    /**
+     * Locks {@code amount} of the funder's balance behind a script.
+     *
+     * THEORY: DEPLOY = A TRANSFER TO A CONDITION
+     *
+     * The deploy is an ordinary transaction whose recipient is the contract's
+     * address (CONTRACT:<id>) and which carries the locking script. It goes
+     * through the pending pool and into a block like any other transfer, so
+     * the funder's balance check, gossip, and mining need no special cases.
+     * The contract becomes OPEN (claimable) once the deploy is mined.
+     *
+     * @param funder Address funding the contract
+     * @param lockingScript Script that guards the funds (e.g. a hashlock)
+     * @param amount Amount to lock
+     * @return The pending deploy transaction, or null if rejected
+     */
+    public Transaction deployContract(String funder, String lockingScript, double amount) {
+        if (funder == null || funder.isBlank()
+                || lockingScript == null || lockingScript.isBlank()) {
+            System.out.println("Contract rejected: funder and locking script are required");
+            return null;
+        }
+
+        // The contract id seeds the contract's address; hashing the deploy
+        // parameters keeps it unique and lets every node derive the same id
+        // from the transaction once it arrives in a block.
+        String contractId = HashUtil.applySha256(
+                funder + lockingScript + amount + System.currentTimeMillis());
+
+        Transaction deploy = new Transaction(
+                funder,
+                BlockchainConfig.CONTRACT_ADDRESS_PREFIX + contractId,
+                amount);
+        deploy.setLockingScript(lockingScript);
+
+        return addTransaction(deploy) ? deploy : null;
+    }
+
+    /**
+     * Claims an OPEN contract by presenting unlocking data.
+     *
+     * The claim is a transaction FROM the contract's address TO the claimer.
+     * addTransaction() runs the unlocking data and the locking script through
+     * the VM; the funds move once the claim is mined. The pending-outgoing
+     * balance check doubles as double-claim protection: a second claim on the
+     * same contract finds no available funds.
+     *
+     * @param contractId Id of the contract to claim
+     * @param claimer Address to credit
+     * @param unlockingScript Data satisfying the locking script (may be empty
+     *                        for pure timelocks)
+     * @return The pending claim transaction, or null if rejected
+     */
+    public Transaction claimContract(String contractId, String claimer, String unlockingScript) {
+        Contract contract = contracts.get(contractId);
+        if (contract == null || claimer == null || claimer.isBlank()) {
+            System.out.println("Claim rejected: Unknown contract or missing claimer");
+            return null;
+        }
+
+        Transaction claim = new Transaction(contract.getAddress(), claimer, contract.getAmount());
+        claim.setUnlockingScript(unlockingScript);
+
+        return addTransaction(claim) ? claim : null;
+    }
+
+    /**
+     * Validates a claim transaction against the contract registry and the
+     * script VM. Used by addTransaction for locally-created claims and for
+     * claims gossiped by peers alike - every node re-verifies every claim.
+     */
+    private boolean isValidClaim(Transaction claim) {
+        String contractId = claim.getSender()
+                .substring(BlockchainConfig.CONTRACT_ADDRESS_PREFIX.length());
+
+        Contract contract = contracts.get(contractId);
+        if (contract == null) {
+            System.out.println("Claim rejected: Unknown contract " + contractId);
+            return false;
+        }
+        if (contract.getStatus() != ContractStatus.OPEN) {
+            System.out.println("Claim rejected: Contract already claimed");
+            return false;
+        }
+        if (claim.getAmount() != contract.getAmount()) {
+            System.out.println("Claim rejected: Amount must equal the locked amount");
+            return false;
+        }
+
+        // The claim height is the index the NEXT block will have - the
+        // earliest height the claim could be mined at (CHECKLOCKTIME).
+        if (!scriptVM.execute(claim.getUnlockingScript(), contract.getLockingScript(), chain.size())) {
+            System.out.println("Claim rejected: Script evaluated to false");
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Scans an appended block for contract deploys and claims and updates the
+     * registry. Called on every block-append path (local mine, external
+     * append, orphan attach), so contract state always mirrors the chain.
+     */
+    private void registerContracts(Block block) {
+        for (Transaction tx : block.getTransactions()) {
+            String recipient = tx.getRecipient();
+            if (recipient.startsWith(BlockchainConfig.CONTRACT_ADDRESS_PREFIX)
+                    && tx.getLockingScript() != null && !tx.getLockingScript().isBlank()) {
+                String id = recipient.substring(BlockchainConfig.CONTRACT_ADDRESS_PREFIX.length());
+                contracts.putIfAbsent(id, new Contract(
+                        id, tx.getSender(), tx.getLockingScript(),
+                        tx.getAmount(), block.getIndex()));
+            }
+
+            String sender = tx.getSender();
+            if (sender.startsWith(BlockchainConfig.CONTRACT_ADDRESS_PREFIX)) {
+                Contract contract = contracts.get(
+                        sender.substring(BlockchainConfig.CONTRACT_ADDRESS_PREFIX.length()));
+                if (contract != null && contract.getStatus() == ContractStatus.OPEN) {
+                    contract.markClaimed(tx.getRecipient());
+                }
+            }
+        }
+    }
+
+    /**
+     * Looks up a contract by id.
+     *
+     * @return The contract, or null if no deploy for this id has been mined
+     */
+    public Contract getContract(String contractId) {
+        return contracts.get(contractId);
+    }
+
+    /**
+     * @return Unmodifiable view of all contracts derived from the chain
+     */
+    public List<Contract> getContracts() {
+        return Collections.unmodifiableList(new ArrayList<>(contracts.values()));
+    }
+
     /**
      * Return the pending transaction pool.
-     * 
+     *
      * @return Unmodifiable list of pending transactions
      */
     public List<Transaction> getPendingTransactions() {

--- a/src/main/java/com/blocksmith/core/Transaction.java
+++ b/src/main/java/com/blocksmith/core/Transaction.java
@@ -42,6 +42,17 @@ public class Transaction {
     private PublicKey senderPublicKey;
 
     /**
+     * Contract scripts (Sprint 14). A DEPLOY transaction (recipient is a
+     * CONTRACT: address) carries the locking script that guards the funds;
+     * a CLAIM transaction (sender is a CONTRACT: address) carries the
+     * unlocking data that satisfies it. Both travel inside blocks so every
+     * node can re-verify the claim and converge on the same contract state.
+     * Null for ordinary transfers.
+     */
+    private String lockingScript;
+    private String unlockingScript;
+
+    /**
      * Creates a new transaction.
      * 
      * @param sender The address sending funds
@@ -186,7 +197,35 @@ public class Transaction {
      */
     public void setSenderPublicKey(PublicKey senderPublicKey) {
         this.senderPublicKey = senderPublicKey;
-    }    
+    }
+
+    /**
+     * Returns the locking script (contract deploy transactions only).
+     */
+    public String getLockingScript() {
+        return lockingScript;
+    }
+
+    /**
+     * Sets the locking script for a contract deploy transaction.
+     */
+    public void setLockingScript(String lockingScript) {
+        this.lockingScript = lockingScript;
+    }
+
+    /**
+     * Returns the unlocking script (contract claim transactions only).
+     */
+    public String getUnlockingScript() {
+        return unlockingScript;
+    }
+
+    /**
+     * Sets the unlocking script for a contract claim transaction.
+     */
+    public void setUnlockingScript(String unlockingScript) {
+        this.unlockingScript = unlockingScript;
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/com/blocksmith/util/BlockchainConfig.java
+++ b/src/main/java/com/blocksmith/util/BlockchainConfig.java
@@ -62,4 +62,12 @@ public final class BlockchainConfig {
      * Currency symbol for display purposes.
     */
     public static final String CURRENCY_SYMBOL = "BSC";
+
+    /**
+     * Address prefix for contract funds (Sprint 14).
+     * A deploy sends funds TO "CONTRACT:<id>"; a claim sends them FROM it.
+     * Like COINBASE, this is a system address convention: no wallet owns it,
+     * and the blockchain enforces who may spend from it (the script VM).
+    */
+    public static final String CONTRACT_ADDRESS_PREFIX = "CONTRACT:";
 }

--- a/src/test/java/com/blocksmith/contract/ChainContractTest.java
+++ b/src/test/java/com/blocksmith/contract/ChainContractTest.java
@@ -1,0 +1,189 @@
+package com.blocksmith.contract;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.blocksmith.core.Blockchain;
+import com.blocksmith.core.Transaction;
+import com.blocksmith.util.BlockchainConfig;
+import com.blocksmith.util.HashUtil;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for contracts on the chain (Milestone 14b): deploy locks funds,
+ * claims run through the script VM, state converges from mined blocks, and
+ * every invalid path is rejected without side effects.
+ */
+@DisplayName("Chain Contract Tests")
+class ChainContractTest {
+
+    private static final String FUNDER = "funder-address";
+    private static final String CLAIMER = "claimer-address";
+    private static final String MINER = "miner-address";
+
+    private static final String SECRET = "open-sesame";
+    private static final String HASHLOCK =
+            "SHA256 PUSH " + HashUtil.applySha256(SECRET) + " EQUAL";
+
+    private Blockchain blockchain;
+
+    @BeforeEach
+    void setUp() {
+        blockchain = new Blockchain();
+        // Fund the funder with a mining reward (50 BSC).
+        blockchain.minePendingTransactions(FUNDER);
+    }
+
+    /** Extracts the contract id from a deploy transaction's recipient. */
+    private static String contractIdOf(Transaction deploy) {
+        return deploy.getRecipient()
+                .substring(BlockchainConfig.CONTRACT_ADDRESS_PREFIX.length());
+    }
+
+    @Test
+    @DisplayName("Deploy locks the funder's balance once mined")
+    void deploy_locksFunderBalance() {
+        Transaction deploy = blockchain.deployContract(FUNDER, HASHLOCK, 20);
+        assertNotNull(deploy, "Deploy within balance should be accepted");
+
+        // Not yet mined: no contract, funds still pending.
+        assertNull(blockchain.getContract(contractIdOf(deploy)));
+
+        blockchain.minePendingTransactions(MINER);
+
+        Contract contract = blockchain.getContract(contractIdOf(deploy));
+        assertNotNull(contract, "Mined deploy should open the contract");
+        assertEquals(ContractStatus.OPEN, contract.getStatus());
+        assertEquals(20, contract.getAmount(), 0.0001);
+        assertEquals(FUNDER, contract.getFunder());
+        assertEquals(30, blockchain.getBalance(FUNDER), 0.0001,
+                "Funder should be debited the locked amount");
+    }
+
+    @Test
+    @DisplayName("Deploy beyond the funder's balance is rejected")
+    void deploy_beyondBalance_rejected() {
+        assertNull(blockchain.deployContract(FUNDER, HASHLOCK, 60),
+                "Funder only has 50");
+        assertEquals(0, blockchain.getPendingCount());
+    }
+
+    @Test
+    @DisplayName("Plain transfer to a contract address is rejected (no script = burned funds)")
+    void plainTransferToContractAddress_rejected() {
+        Transaction burn = new Transaction(
+                FUNDER, BlockchainConfig.CONTRACT_ADDRESS_PREFIX + "deadbeef", 5);
+        assertFalse(blockchain.addTransaction(burn));
+    }
+
+    @Test
+    @DisplayName("Claim with the correct preimage credits the claimer")
+    void claim_withCorrectPreimage_creditsClaimer() {
+        Transaction deploy = blockchain.deployContract(FUNDER, HASHLOCK, 20);
+        blockchain.minePendingTransactions(MINER);
+        String id = contractIdOf(deploy);
+
+        Transaction claim = blockchain.claimContract(id, CLAIMER, "PUSH " + SECRET);
+        assertNotNull(claim, "Correct preimage should unlock the contract");
+
+        blockchain.minePendingTransactions(MINER);
+
+        assertEquals(20, blockchain.getBalance(CLAIMER), 0.0001);
+        assertEquals(ContractStatus.CLAIMED, blockchain.getContract(id).getStatus());
+        assertEquals(CLAIMER, blockchain.getContract(id).getClaimer());
+    }
+
+    @Test
+    @DisplayName("Claim with a wrong preimage is rejected without side effects")
+    void claim_withWrongPreimage_rejected() {
+        Transaction deploy = blockchain.deployContract(FUNDER, HASHLOCK, 20);
+        blockchain.minePendingTransactions(MINER);
+        String id = contractIdOf(deploy);
+
+        assertNull(blockchain.claimContract(id, CLAIMER, "PUSH wrong-word"));
+
+        assertEquals(0, blockchain.getBalance(CLAIMER), 0.0001);
+        assertEquals(ContractStatus.OPEN, blockchain.getContract(id).getStatus());
+        assertEquals(0, blockchain.getPendingCount(), "No claim should be pending");
+    }
+
+    @Test
+    @DisplayName("Timelock claim: rejected before height N, accepted after")
+    void timelockClaim_beforeHeight_rejected_afterHeight_accepted() {
+        // Chain: genesis(0) + funding(1). Deploy will be mined into block 2.
+        Transaction deploy = blockchain.deployContract(FUNDER, "PUSH 5 CHECKLOCKTIME", 15);
+        blockchain.minePendingTransactions(MINER);
+        String id = contractIdOf(deploy);
+
+        // Next block would be #3 - too early for height 5.
+        assertNull(blockchain.claimContract(id, CLAIMER, ""),
+                "Claim should be rejected before the lock height");
+
+        // Mine empty-pool blocks (coinbase only) until the next block is #5.
+        blockchain.minePendingTransactions(MINER); // 3
+        blockchain.minePendingTransactions(MINER); // 4
+
+        Transaction claim = blockchain.claimContract(id, CLAIMER, "");
+        assertNotNull(claim, "Claim should be accepted once the chain is tall enough");
+
+        blockchain.minePendingTransactions(MINER);
+        assertEquals(15, blockchain.getBalance(CLAIMER), 0.0001);
+    }
+
+    @Test
+    @DisplayName("Double claim is rejected - both pending and after mining")
+    void doubleClaim_rejected() {
+        Transaction deploy = blockchain.deployContract(FUNDER, HASHLOCK, 20);
+        blockchain.minePendingTransactions(MINER);
+        String id = contractIdOf(deploy);
+
+        // First claim enters the pool; a second pending claim finds no
+        // available funds (pending-outgoing check).
+        assertNotNull(blockchain.claimContract(id, CLAIMER, "PUSH " + SECRET));
+        assertNull(blockchain.claimContract(id, "someone-else", "PUSH " + SECRET),
+                "Second pending claim should be rejected");
+
+        blockchain.minePendingTransactions(MINER);
+
+        // After mining the contract is CLAIMED - further claims are rejected.
+        assertNull(blockchain.claimContract(id, "someone-else", "PUSH " + SECRET),
+                "Claim on a CLAIMED contract should be rejected");
+        assertEquals(20, blockchain.getBalance(CLAIMER), 0.0001);
+        assertEquals(0, blockchain.getBalance("someone-else"), 0.0001);
+    }
+
+    @Test
+    @DisplayName("Claim before the deploy is mined is rejected")
+    void claim_beforeDeployMined_rejected() {
+        Transaction deploy = blockchain.deployContract(FUNDER, HASHLOCK, 20);
+        assertNull(blockchain.claimContract(contractIdOf(deploy), CLAIMER, "PUSH " + SECRET),
+                "Contract does not exist until the deploy is mined");
+    }
+
+    @Test
+    @DisplayName("External blocks build the same contract state (network convergence)")
+    void externalBlocks_buildSameContractState() {
+        // Node A mines the full lifecycle; node B replays A's blocks.
+        Blockchain nodeB = new Blockchain();
+
+        Transaction deploy = blockchain.deployContract(FUNDER, HASHLOCK, 20);
+        blockchain.minePendingTransactions(MINER);
+        String id = contractIdOf(deploy);
+        blockchain.claimContract(id, CLAIMER, "PUSH " + SECRET);
+        blockchain.minePendingTransactions(MINER);
+
+        // Replay A's mined blocks (skip the shared genesis) onto B.
+        for (int i = 1; i < blockchain.getChainSize(); i++) {
+            assertTrue(nodeB.addBlock(blockchain.getBlock(i)),
+                    "Block " + i + " should append cleanly on node B");
+        }
+
+        Contract onB = nodeB.getContract(id);
+        assertNotNull(onB, "Node B should derive the contract from the blocks");
+        assertEquals(ContractStatus.CLAIMED, onB.getStatus());
+        assertEquals(CLAIMER, onB.getClaimer());
+        assertEquals(20, nodeB.getBalance(CLAIMER), 0.0001);
+    }
+}


### PR DESCRIPTION
Second milestone of Sprint 14: the script VM meets the blockchain. Funds can now be locked behind a script and claimed by whoever satisfies it.

## Design: contracts as transactions, state as a view
- A **deploy** is an ordinary transaction whose recipient is `CONTRACT:<id>`, carrying the locking script (mirrors the existing `COINBASE` address convention). A **claim** is a transaction FROM that address, carrying the unlocking data.
- Because deploys/claims are just transactions, the existing balance model debits the funder and credits the claimer with **zero changes to `getBalance`**, and gossip/mining need no special cases.
- The **contract registry is derived state**: every block-append path (local mine, external append, orphan attach) scans for deploys/claims. All nodes replay the same blocks -> all nodes derive the same registry, exactly like balances.

## What's new
- `Contract` + `ContractStatus` (OPEN/CLAIMED) in `com.blocksmith.contract`
- `Transaction`: optional `lockingScript`/`unlockingScript` fields (same pattern as the optional signature fields) - they travel in blocks so every node re-verifies claims
- `Blockchain`: `deployContract`, `claimContract`, `getContract(s)`, registry hook `registerContracts`, and two `addTransaction` rules:
  - transfer TO a contract address without a locking script -> rejected (would burn funds)
  - transfer FROM one -> validated as a claim: contract OPEN, amount matches, `ScriptVM` passes at next-block height
- Double-claim protection falls out of the existing pending-outgoing balance check; claimed contracts reject further claims via status.
- `BlockchainConfig.CONTRACT_ADDRESS_PREFIX`

## Tests
`ChainContractTest` - **9 tests**: deploy locks balance, over-balance deploy rejected, script-less transfer to a contract address rejected, hashlock claim credits claimer, wrong preimage rejected without side effects, timelock before/after height, double claim (pending + mined), claim before deploy mined, and **network convergence** (a second node replays the blocks and derives identical contract state).

**Full suite: 217 passing** (was 208).

Closes #139, #140.