### PR TITLE
Sprint 14c: Contract endpoints + dashboard panel

### DIFF
--- a/src/main/java/com/blocksmith/api/ApiServer.java
+++ b/src/main/java/com/blocksmith/api/ApiServer.java
@@ -5,10 +5,12 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.blocksmith.contract.Contract;
 import com.blocksmith.core.Block;
 import com.blocksmith.core.Blockchain;
 import com.blocksmith.core.Transaction;
 import com.blocksmith.core.Wallet;
+import com.blocksmith.util.BlockchainConfig;
 import com.blocksmith.network.NetworkConfig;
 import com.blocksmith.network.Node;
 import com.blocksmith.network.PeerInfo;
@@ -97,6 +99,12 @@ public class ApiServer {
         app.get("/api/wallet/{address}", this::getWallet);
         app.post("/api/wallet/create", this::postWalletCreate);
         app.get("/api/network/peers", this::getPeers);
+
+        // Contract endpoints (Milestone 14c).
+        app.get("/api/contracts", ctx -> json(ctx, contractsList()));
+        app.get("/api/contracts/{id}", this::getContract);
+        app.post("/api/contracts", this::postContract);
+        app.post("/api/contracts/{id}/claim", this::postContractClaim);
 
         // JSON error handling (Milestone 12c).
         app.exception(Exception.class, (e, ctx) -> {
@@ -242,6 +250,123 @@ public class ApiServer {
             if (address.equals(tx.getSender())) sum += tx.getAmount();
         }
         return sum;
+    }
+
+    // ===== 14c: CONTRACTS =====
+
+    /**
+     * Deploys a contract: locks an amount behind a locking script. The deploy
+     * enters the mempool as a transaction and propagates to peers; the contract
+     * itself becomes OPEN once the deploy is mined.
+     */
+    private void postContract(Context ctx) {
+        JsonObject body;
+        try {
+            body = JsonParser.parseString(ctx.body()).getAsJsonObject();
+        } catch (JsonSyntaxException | IllegalStateException e) {
+            ctx.status(400);
+            json(ctx, error("Request body must be a JSON object"));
+            return;
+        }
+
+        if (!body.has("funder") || !body.has("amount") || !body.has("lockingScript")) {
+            ctx.status(400);
+            json(ctx, error("Contract requires funder, amount, and lockingScript"));
+            return;
+        }
+
+        Transaction deploy = blockchain.deployContract(
+                body.get("funder").getAsString(),
+                body.get("lockingScript").getAsString(),
+                body.get("amount").getAsDouble());
+
+        if (deploy == null) {
+            ctx.status(400);
+            json(ctx, error("Contract deploy rejected (invalid script or insufficient funds)"));
+            return;
+        }
+
+        node.broadcastTransaction(deploy);
+        ctx.status(201);
+
+        // The contract id is the deploy recipient minus the address prefix.
+        String contractId = deploy.getRecipient()
+                .substring(BlockchainConfig.CONTRACT_ADDRESS_PREFIX.length());
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("contractId", contractId);
+        m.put("funder", deploy.getSender());
+        m.put("amount", deploy.getAmount());
+        m.put("lockingScript", deploy.getLockingScript());
+        m.put("status", "PENDING"); // OPEN once the deploy is mined
+        json(ctx, m);
+    }
+
+    /** Claims an OPEN contract with unlocking data. */
+    private void postContractClaim(Context ctx) {
+        String id = ctx.pathParam("id");
+
+        JsonObject body;
+        try {
+            body = JsonParser.parseString(ctx.body()).getAsJsonObject();
+        } catch (JsonSyntaxException | IllegalStateException e) {
+            ctx.status(400);
+            json(ctx, error("Request body must be a JSON object"));
+            return;
+        }
+
+        if (!body.has("claimer")) {
+            ctx.status(400);
+            json(ctx, error("Claim requires a claimer address"));
+            return;
+        }
+
+        String unlockingScript = body.has("unlockingScript")
+                ? body.get("unlockingScript").getAsString() : "";
+
+        Transaction claim = blockchain.claimContract(
+                id, body.get("claimer").getAsString(), unlockingScript);
+
+        if (claim == null) {
+            ctx.status(400);
+            json(ctx, error("Claim rejected (unknown/claimed contract or script failed)"));
+            return;
+        }
+
+        node.broadcastTransaction(claim);
+        ctx.status(201);
+        json(ctx, contractInfo(blockchain.getContract(id)));
+    }
+
+    /** Returns a single contract by id (404 if no deploy has been mined). */
+    private void getContract(Context ctx) {
+        Contract contract = blockchain.getContract(ctx.pathParam("id"));
+        if (contract == null) {
+            ctx.status(404);
+            json(ctx, error("No contract with id " + ctx.pathParam("id")));
+            return;
+        }
+        json(ctx, contractInfo(contract));
+    }
+
+    private List<Map<String, Object>> contractsList() {
+        List<Map<String, Object>> list = new ArrayList<>();
+        for (Contract contract : blockchain.getContracts()) {
+            list.add(contractInfo(contract));
+        }
+        return list;
+    }
+
+    /** Serializes a contract to a stable JSON shape for the UI. */
+    private Map<String, Object> contractInfo(Contract contract) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("contractId", contract.getContractId());
+        m.put("funder", contract.getFunder());
+        m.put("lockingScript", contract.getLockingScript());
+        m.put("amount", contract.getAmount());
+        m.put("creationHeight", contract.getCreationHeight());
+        m.put("status", contract.getStatus().toString());
+        m.put("claimer", contract.getClaimer());
+        return m;
     }
 
     private void getBlockByIndex(Context ctx) {

--- a/src/main/resources/public/app.js
+++ b/src/main/resources/public/app.js
@@ -100,6 +100,36 @@ function renderBlocks(blocks) {
     }
 }
 
+function renderContracts(contracts) {
+    const list = document.getElementById("contract-list");
+    list.replaceChildren();
+
+    if (contracts.length === 0) {
+        list.appendChild(el("p", "muted", "No contracts deployed yet"));
+        return;
+    }
+
+    // Newest first (registry is insertion-ordered by deploy).
+    for (let i = contracts.length - 1; i >= 0; i--) {
+        const c = contracts[i];
+        const claimed = c.status === "CLAIMED";
+        const card = el("div", claimed ? "contract claimed" : "contract");
+
+        const head = el("div", "block-head");
+        head.appendChild(el("span", "block-index", c.amount + " BSC"));
+        head.appendChild(el("span", claimed ? "contract-status claimed" : "contract-status open", c.status));
+        card.appendChild(head);
+
+        card.appendChild(el("div", "block-hash", "id " + shortHash(c.contractId)));
+        card.appendChild(el("div", "block-prev", "lock " + c.lockingScript));
+        card.appendChild(el("div", "block-nonce", "funder " + shortHash(c.funder)));
+        if (claimed && c.claimer) {
+            card.appendChild(el("div", "block-nonce", "claimer " + shortHash(c.claimer)));
+        }
+        list.appendChild(card);
+    }
+}
+
 function setStatus(text, ok) {
     const bar = document.getElementById("refresh-status");
     bar.textContent = text;
@@ -167,17 +197,44 @@ function wireActions() {
             return "Mined block #" + block.index + " (" + shortHash(block.hash) + ")";
         });
     });
+
+    document.getElementById("deploy-contract").addEventListener("click", function () {
+        runAction("deploy-result", async function () {
+            const contract = await postJson("/api/contracts", {
+                funder: document.getElementById("deploy-funder").value.trim(),
+                amount: Number(document.getElementById("deploy-amount").value),
+                lockingScript: document.getElementById("deploy-script").value.trim()
+            });
+            // Hand the id straight to the claim form; mine to activate it.
+            document.getElementById("claim-id").value = contract.contractId;
+            return "Deployed " + shortHash(contract.contractId) + " (mine to activate)";
+        });
+    });
+
+    document.getElementById("claim-contract").addEventListener("click", function () {
+        runAction("claim-result", async function () {
+            const id = document.getElementById("claim-id").value.trim();
+            if (!id) throw new Error("Enter a contract id to claim");
+            const contract = await postJson("/api/contracts/" + encodeURIComponent(id) + "/claim", {
+                claimer: document.getElementById("claim-claimer").value.trim(),
+                unlockingScript: document.getElementById("claim-unlock").value.trim()
+            });
+            return "Claim submitted for " + shortHash(contract.contractId) + " (mine to settle)";
+        });
+    });
 }
 
 async function refresh() {
     try {
-        const [status, peers, blocks] = await Promise.all([
+        const [status, peers, blocks, contracts] = await Promise.all([
             fetchJson("/api/network/status"),
             fetchJson("/api/network/peers"),
-            fetchJson("/api/blocks")
+            fetchJson("/api/blocks"),
+            fetchJson("/api/contracts")
         ]);
         renderNetwork(status, peers);
         renderBlocks(blocks);
+        renderContracts(contracts);
         setStatus("Updated · refreshing every " + (REFRESH_MS / 1000) + "s", true);
     } catch (e) {
         setStatus("Cannot reach the node API: " + e.message, false);

--- a/src/main/resources/public/index.html
+++ b/src/main/resources/public/index.html
@@ -50,6 +50,30 @@
             </div>
         </section>
 
+        <section id="contracts">
+            <h2>Contracts</h2>
+            <div class="action-grid">
+                <div class="action">
+                    <h3>Deploy</h3>
+                    <input id="deploy-funder" type="text" placeholder="funder address" autocomplete="off">
+                    <input id="deploy-amount" type="number" placeholder="amount to lock" min="0" step="any" autocomplete="off">
+                    <input id="deploy-script" type="text" placeholder="locking script (e.g. SHA256 PUSH &lt;hash&gt; EQUAL)" autocomplete="off">
+                    <button id="deploy-contract">Deploy contract</button>
+                    <p id="deploy-result" class="action-result"></p>
+                </div>
+
+                <div class="action">
+                    <h3>Claim</h3>
+                    <input id="claim-id" type="text" placeholder="contract id" autocomplete="off">
+                    <input id="claim-claimer" type="text" placeholder="claimer address" autocomplete="off">
+                    <input id="claim-unlock" type="text" placeholder="unlocking data (e.g. PUSH &lt;preimage&gt;)" autocomplete="off">
+                    <button id="claim-contract">Claim contract</button>
+                    <p id="claim-result" class="action-result"></p>
+                </div>
+            </div>
+            <div id="contract-list"></div>
+        </section>
+
         <section id="blocks">
             <h2>Blocks</h2>
             <div id="block-list"></div>

--- a/src/main/resources/public/style.css
+++ b/src/main/resources/public/style.css
@@ -210,6 +210,42 @@ section h2 {
 .action-result.ok { color: var(--accent); }
 .action-result.error { color: #ff6b6b; }
 
+/* Contract cards (Sprint 14c) */
+#contract-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: 0.75rem;
+    margin-top: 1rem;
+}
+
+.contract {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.75rem;
+    font-family: ui-monospace, Consolas, monospace;
+    font-size: 0.8rem;
+}
+
+.contract.claimed { opacity: 0.7; }
+
+.contract-status {
+    font-size: 0.7rem;
+    font-weight: 700;
+    padding: 0.1rem 0.4rem;
+    border-radius: 4px;
+}
+
+.contract-status.open {
+    color: #1a1200;
+    background: var(--accent);
+}
+
+.contract-status.claimed {
+    color: var(--muted);
+    border: 1px solid var(--border);
+}
+
 footer {
     padding: 1.5rem 2rem;
     border-top: 1px solid var(--border);

--- a/src/test/java/com/blocksmith/api/ApiContractsTest.java
+++ b/src/test/java/com/blocksmith/api/ApiContractsTest.java
@@ -1,0 +1,149 @@
+package com.blocksmith.api;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.blocksmith.network.Node;
+import com.blocksmith.util.HashUtil;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Server-side tests for the Milestone 14c contract endpoints. Drives the same
+ * HTTP chain the dashboard's Contracts panel hits - deploy, mine, inspect,
+ * claim, mine - and confirms funds move and rejections carry an error envelope.
+ */
+@DisplayName("API Contracts Tests")
+class ApiContractsTest {
+
+    private static final int API_PORT_BASE = 17600;
+    private static final int P2P_PORT_BASE = 19100;
+    private static int counter = 0;
+
+    private static final String FUNDER = "funder-address";
+    private static final String CLAIMER = "claimer-address";
+    private static final String MINER = "miner-address";
+    private static final String SECRET = "open-sesame";
+
+    private Node node;
+    private ApiServer api;
+    private int apiPort;
+    private final HttpClient client = HttpClient.newHttpClient();
+
+    @BeforeEach
+    void setUp() {
+        int offset = counter++;
+        apiPort = API_PORT_BASE + offset;
+        node = new Node(P2P_PORT_BASE + offset);
+        api = new ApiServer(node, apiPort);
+        api.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (api != null) api.stop();
+        if (node != null) node.stop();
+    }
+
+    private HttpResponse<String> get(String path) throws Exception {
+        return client.send(
+                HttpRequest.newBuilder()
+                        .uri(URI.create("http://localhost:" + apiPort + path))
+                        .GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    private HttpResponse<String> post(String path, String body) throws Exception {
+        return client.send(
+                HttpRequest.newBuilder()
+                        .uri(URI.create("http://localhost:" + apiPort + path))
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString(body))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    private static JsonObject json(HttpResponse<String> res) {
+        return JsonParser.parseString(res.body()).getAsJsonObject();
+    }
+
+    private void mineTo(String address) throws Exception {
+        post("/api/mine", "{\"minerAddress\":\"" + address + "\"}");
+    }
+
+    @Test
+    @DisplayName("Contract lifecycle over HTTP: deploy, mine, inspect, claim, settle")
+    void contractLifecycle_overHttp() throws Exception {
+        // Give the funder a mining reward to lock.
+        mineTo(FUNDER);
+
+        // Deploy a hashlock contract.
+        String hashlock = "SHA256 PUSH " + HashUtil.applySha256(SECRET) + " EQUAL";
+        String deployBody = "{\"funder\":\"" + FUNDER + "\",\"amount\":20,"
+                + "\"lockingScript\":\"" + hashlock + "\"}";
+        HttpResponse<String> deployed = post("/api/contracts", deployBody);
+        assertEquals(201, deployed.statusCode());
+        String contractId = json(deployed).get("contractId").getAsString();
+
+        // Mine the deploy: the contract becomes OPEN.
+        mineTo(MINER);
+        HttpResponse<String> inspected = get("/api/contracts/" + contractId);
+        assertEquals(200, inspected.statusCode());
+        assertEquals("OPEN", json(inspected).get("status").getAsString());
+        assertEquals(20.0, json(inspected).get("amount").getAsDouble(), 0.0001);
+
+        // Claim with the correct preimage, then mine to settle.
+        String claimBody = "{\"claimer\":\"" + CLAIMER + "\",\"unlockingScript\":\"PUSH " + SECRET + "\"}";
+        assertEquals(201, post("/api/contracts/" + contractId + "/claim", claimBody).statusCode());
+        mineTo(MINER);
+
+        assertEquals("CLAIMED", json(get("/api/contracts/" + contractId)).get("status").getAsString());
+        assertEquals(20.0, json(get("/api/wallet/" + CLAIMER)).get("balance").getAsDouble(), 0.0001,
+                "Claimer should receive the locked amount once settled");
+    }
+
+    @Test
+    @DisplayName("GET /api/contracts lists deployed contracts")
+    void contractsList_reflectsDeploys() throws Exception {
+        mineTo(FUNDER);
+        String hashlock = "SHA256 PUSH " + HashUtil.applySha256(SECRET) + " EQUAL";
+        post("/api/contracts", "{\"funder\":\"" + FUNDER + "\",\"amount\":10,"
+                + "\"lockingScript\":\"" + hashlock + "\"}");
+        mineTo(MINER);
+
+        HttpResponse<String> res = get("/api/contracts");
+        assertEquals(200, res.statusCode());
+        assertTrue(JsonParser.parseString(res.body()).getAsJsonArray().size() >= 1);
+    }
+
+    @Test
+    @DisplayName("Rejected deploy and claim return an error envelope")
+    void rejectedDeployAndClaim_returnErrorEnvelope() throws Exception {
+        // Deploy beyond the funder's (zero) balance -> 400 + error.
+        String hashlock = "SHA256 PUSH " + HashUtil.applySha256(SECRET) + " EQUAL";
+        HttpResponse<String> badDeploy = post("/api/contracts",
+                "{\"funder\":\"" + FUNDER + "\",\"amount\":999,\"lockingScript\":\"" + hashlock + "\"}");
+        assertEquals(400, badDeploy.statusCode());
+        assertTrue(json(badDeploy).has("error"));
+
+        // Claim an unknown contract -> 400 + error.
+        HttpResponse<String> badClaim = post("/api/contracts/nope/claim",
+                "{\"claimer\":\"" + CLAIMER + "\",\"unlockingScript\":\"PUSH " + SECRET + "\"}");
+        assertEquals(400, badClaim.statusCode());
+        assertTrue(json(badClaim).has("error"));
+
+        // Missing required fields -> 400 + error.
+        HttpResponse<String> missing = post("/api/contracts", "{\"funder\":\"" + FUNDER + "\"}");
+        assertEquals(400, missing.statusCode());
+        assertTrue(json(missing).has("error"));
+    }
+}


### PR DESCRIPTION
Final milestone of Sprint 14: contracts become drivable end to end from HTTP and the browser. **Verified live** against a running node - deploy locks funds, the correct preimage settles the claim, a wrong preimage is rejected with an error envelope.

## Endpoints (`ApiServer`)
- `POST /api/contracts` - deploy (funder, amount, lockingScript) -> 201 with the contract id; broadcasts the deploy so peers see it
- `GET /api/contracts`, `GET /api/contracts/{id}` - inspect (404 if no deploy mined)
- `POST /api/contracts/{id}/claim` - claim (claimer, unlockingScript) -> broadcasts the claim
- Rejections return the same JSON `{"error": ...}` envelope as Sprint 12

## Dashboard (Contracts panel)
- Deploy form (funder / amount / locking script) and claim form (id / claimer / unlocking data)
- A successful deploy hands the new id straight to the claim form
- Contract cards list id, amount, status (OPEN highlighted / CLAIMED dimmed), funder, and claimer; polled with the rest of the dashboard
- Errors surfaced inline, consistent with 13c; all values via `textContent`

## Live verification (against `BlockSmithNode`)
```
mine -> funder 50
deploy 20 (hashlock)      -> funder 30, contract PENDING
mine                       -> contract OPEN @ height 2
claim PUSH open-sesame     -> accepted
mine                       -> CLAIMED, claimer credited 20
claim wrong preimage       -> 400 {"error": "Claim rejected ..."}
```

## Tests
`ApiContractsTest` - 3 tests: full lifecycle over HTTP (deploy -> mine -> inspect -> claim -> settle -> balances move), list reflects deploys, and rejected deploy/claim/missing-fields all return an error envelope.

**Full suite: 220 passing** (was 217).

> Note: the README's run command (`java -cp target/classes`) omits the dependency jars - I'll correct it to a working classpath in the Sprint 14 docs PR.

Closes #142, #143.