### PR TITLE
docs: Sprint 14 complete (Smart Contracts) + run-command fix

### DIFF
--- a/.ai/ARCHITECTURE.md
+++ b/.ai/ARCHITECTURE.md
@@ -318,7 +318,7 @@ byte[] hash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
 
 **Run With**:
 ```bash
-mvn compile -q; java -cp target/classes com.blocksmith.BlockSmithDemo
+mvn exec:java -Dexec.mainClass=com.blocksmith.BlockSmithDemo
 ```
 
 ---

--- a/.ai/ONBOARDING.md
+++ b/.ai/ONBOARDING.md
@@ -39,9 +39,9 @@
 | **Test Framework** | JUnit 5 |
 | **Serialization** | Gson 2.10.1 |
 | **Current Phase** | Phase 3: API & Interface — In Progress |
-| **Current Sprint** | Sprint 13 (Web Dashboard) — Complete |
-| **Current Milestone** | 13c Complete; next: Sprint 14 (Smart Contracts) |
-| **Total Tests** | 187 (all passing) |
+| **Current Sprint** | Sprint 14 (Smart Contracts) — Complete |
+| **Current Milestone** | 14c Complete; next: Sprint 15 (Multi-sig Wallets) |
+| **Total Tests** | 220 (all passing) |
 | **Main Branch** | `master` |
 
 ---
@@ -113,11 +113,16 @@ BlockSmith/
 │           └── MempoolMessage.java   # ✅ Complete (Sprint 11c)
 │
 │   ├── api/                          # REST API (Sprint 12)
-│   │   └── ApiServer.java            # ✅ Complete (Javalin: blocks, tx, mine, wallet, network + static hosting)
+│   │   └── ApiServer.java            # ✅ Complete (Javalin: blocks, tx, mine, wallet, network, contracts + static hosting)
+│   ├── contract/                     # Smart contracts (Sprint 14)
+│   │   ├── ScriptOp.java             # ✅ Opcode set
+│   │   ├── ScriptVM.java             # ✅ Stack-based interpreter (hashlock/timelock)
+│   │   ├── Contract.java             # ✅ Contract model (derived from chain)
+│   │   └── ContractStatus.java       # ✅ OPEN / CLAIMED
 │   └── BlockSmithNode.java           # ✅ Complete (runnable node: P2P + API + dashboard, Sprint 13a)
 │
-├── src/main/resources/public/        # Web dashboard (Sprint 13): index.html, app.js, style.css
-├── src/test/java/com/blocksmith/     # 187 unit tests
+├── src/main/resources/public/        # Web dashboard (Sprint 13-14): index.html, app.js, style.css
+├── src/test/java/com/blocksmith/     # 220 unit tests
 ├── pom.xml                           # Maven configuration (Gson, JUnit, Javalin)
 └── README.md                         # Public documentation
 ```
@@ -149,14 +154,16 @@ BlockSmith/
 
 **Sprint 12: REST API** — Javalin `ApiServer` on port 7070: block read endpoints + network status, transaction submit/lookup + mining (broadcast on write), wallet balance/create + peers, JSON error envelope (400/404/500).
 
-**Sprint 13: Web Dashboard** — `BlockSmithNode` runnable entry point (Node + ApiServer in one process), Javalin static hosting of a vanilla HTML/JS/CSS dashboard at `/`: explorer view (blocks + network, 4s polling) and actions (create wallet, balance lookup, send tx, mine) with API errors surfaced inline. Run: `java -cp target/classes com.blocksmith.BlockSmithNode` → `http://localhost:7070/`.
+**Sprint 13: Web Dashboard** — `BlockSmithNode` runnable entry point (Node + ApiServer in one process), Javalin static hosting of a vanilla HTML/JS/CSS dashboard at `/`: explorer view (blocks + network, 4s polling) and actions (create wallet, balance lookup, send tx, mine) with API errors surfaced inline. Run: `mvn exec:java` → `http://localhost:7070/`.
+
+**Sprint 14: Smart Contracts** — `com.blocksmith.contract`: `ScriptVM` stack machine (opcodes for hashlock/timelock; never throws — malformed scripts evaluate to false). Contracts are modelled as transactions (deploy TO `CONTRACT:<id>` with a locking script, claim FROM it with unlocking data), so the balance model needs no changes; the contract registry is derived from blocks so all nodes converge. REST: `POST /api/contracts`, `GET /api/contracts[/{id}]`, `POST /api/contracts/{id}/claim`; dashboard Contracts panel.
 
 ---
 
 ## What's NOT Implemented Yet
 
-### Phase 3 remaining (Sprints 14-15) ← NEXT
-- Basic smart contracts (Sprint 14), multi-sig wallets (Sprint 15)
+### Phase 3 remaining (Sprint 15) ← NEXT
+- Multi-sig wallets (Sprint 15): M-of-N signatures, threshold signing
 
 ### Phase 4: Production Features (Sprints 16-19)
 - Database persistence, dynamic difficulty, block limits, fee market
@@ -180,8 +187,11 @@ mvn test
 # Run specific test class
 mvn test -Dtest=MempoolSyncTest
 
-# Run the demo (PowerShell)
-mvn compile -q; java -cp target/classes com.blocksmith.BlockSmithDemo
+# Run the node + web dashboard (http://localhost:7070/)
+mvn exec:java
+
+# Run the teaching demo
+mvn exec:java -Dexec.mainClass=com.blocksmith.BlockSmithDemo
 ```
 
 ---
@@ -247,7 +257,10 @@ mvn compile -q; java -cp target/classes com.blocksmith.BlockSmithDemo
 | ApiStaticHostingTest | 3 | Dashboard shell + static assets alongside the API (Sprint 13a) |
 | ApiExplorerTest | 2 | Explorer mount points + block JSON shape (Sprint 13b) |
 | ApiDashboardActionsTest | 2 | Dashboard action chain end to end (Sprint 13c) |
-| **Total** | **187** | All passing ✅ |
+| ScriptVMTest | 21 | Script opcodes, hashlock/timelock, failure semantics (Sprint 14a) |
+| ChainContractTest | 9 | Contract deploy/claim, timelock, double-claim, convergence (Sprint 14b) |
+| ApiContractsTest | 3 | Contract lifecycle over HTTP + error envelopes (Sprint 14c) |
+| **Total** | **220** | All passing ✅ |
 
 ---
 
@@ -258,7 +271,7 @@ mvn compile -q; java -cp target/classes com.blocksmith.BlockSmithDemo
 - **Doc branches**: `docs/{description}` (e.g., `docs/sprint11-complete`)
 - **Commits**: One per issue, format: `feat(scope): description #NN` — never add `Co-Authored-By`
 - **PRs**: created with `gh`, include `Closes #NN` lines, ff-only merge to sync local master
-- **Latest**: Sprint 13 complete (Web Dashboard, PR #133); Phase 3 in progress
+- **Latest**: Sprint 14 complete (Smart Contracts, PR #144); Phase 3 in progress
 
 ---
 
@@ -270,9 +283,9 @@ mvn compile -q; java -cp target/classes com.blocksmith.BlockSmithDemo
 | `CONVENTIONS.md` | Need full code style rules, THEORY comment format, test conventions |
 | `STATUS.md` | Need exact current status, implementation table, feature checklist |
 | `roadmap.md` | Need full project phases and timeline |
-| `sprints/sprint13/sprint-plan.md` | Most recent sprint's milestones, issues, acceptance criteria |
-| `sprints/sprint13/sprint-log.md` | What was completed in the latest sprint |
+| `sprints/sprint14/sprint-plan.md` | Most recent sprint's milestones, issues, acceptance criteria |
+| `sprints/sprint14/sprint-log.md` | What was completed in the latest sprint |
 
 ---
 
-*Last updated: 2026-07-03 | Sprint 13 Complete (Milestone 13c) — Phase 3 In Progress*
+*Last updated: 2026-07-03 | Sprint 14 Complete (Milestone 14c) — Phase 3 In Progress*

--- a/.ai/STATUS.md
+++ b/.ai/STATUS.md
@@ -9,9 +9,9 @@
 | Field | Value |
 |-------|-------|
 | **Phase** | 3 - API & Interface - In Progress |
-| **Current Sprint** | 13 (Web Dashboard) - Complete |
-| **Current Milestone** | 13c Complete (Wallet + transaction actions) |
-| **Status** | Sprint 13 complete (13a-13c), next: Sprint 14 (Smart Contracts) |
+| **Current Sprint** | 14 (Smart Contracts) - Complete |
+| **Current Milestone** | 14c Complete (Contract endpoints + dashboard panel) |
+| **Status** | Sprint 14 complete (14a-14c), next: Sprint 15 (Multi-sig Wallets) |
 
 ---
 
@@ -46,11 +46,11 @@ Phase 2: Network Layer       [███████████████] 100
 ├── Sprint 10: Broadcasting  ✅ COMPLETE (10a ✅, 10b ✅, 10c ✅, 10d ✅)
 └── Sprint 11: Mempool Sync  ✅ COMPLETE (11a ✅, 11b ✅, 11c ✅)
 
-Phase 3: API & Interface     [████████░░░░░░░] 50% ← CURRENT
+Phase 3: API & Interface     [███████████░░░░] 75% ← CURRENT
 ├── Sprint 12: REST API      ✅ COMPLETE (12a ✅, 12b ✅, 12c ✅)
 ├── Sprint 13: Web Dashboard ✅ COMPLETE (13a ✅, 13b ✅, 13c ✅)
-├── Sprint 14: Smart Contracts ⬜ ← NEXT
-└── Sprint 15: Multi-sig Wallets ⬜
+├── Sprint 14: Smart Contracts ✅ COMPLETE (14a ✅, 14b ✅, 14c ✅)
+└── Sprint 15: Multi-sig Wallets ⬜ ← NEXT
 ```
 
 ---
@@ -87,7 +87,10 @@ Phase 3: API & Interface     [████████░░░░░░░] 50%
 | ApiStaticHostingTest | 3 | ✅ |
 | ApiExplorerTest | 2 | ✅ |
 | ApiDashboardActionsTest | 2 | ✅ |
-| **Total** | **187** | ✅ |
+| ScriptVMTest | 21 | ✅ |
+| ChainContractTest | 9 | ✅ |
+| ApiContractsTest | 3 | ✅ |
+| **Total** | **220** | ✅ |
 
 Last test run: `mvn test` - All passing
 
@@ -100,8 +103,8 @@ Last test run: `mvn test` - All passing
 | Class | Status | Lines | Notes |
 |-------|--------|-------|-------|
 | Block.java | ✅ Complete | ~268 | Transactions + Merkle root |
-| Blockchain.java | ✅ Complete | ~495 | Pending pool + mining + external append + orphan buffer (Sprint 10) + tx dedupe + mempool prune (Sprint 11) |
-| Transaction.java | ✅ Complete | ~200 | Validation + signing + verification |
+| Blockchain.java | ✅ Complete | ~640 | Pending pool + mining + external append + orphan buffer (Sprint 10) + tx dedupe + mempool prune (Sprint 11) + contract registry (deploy/claim, derived from chain) (Sprint 14b) |
+| Transaction.java | ✅ Complete | ~230 | Validation + signing + verification + optional contract locking/unlocking scripts (Sprint 14b) |
 | Wallet.java | ✅ Complete | ~169 | ECDSA keys + signing |
 
 ### Utility Classes (`com.blocksmith.util`)
@@ -134,7 +137,16 @@ Last test run: `mvn test` - All passing
 
 | Class | Status | Lines | Notes |
 |-------|--------|-------|-------|
-| ApiServer.java | ✅ Complete | ~300 | Javalin REST API: blocks, transactions, mining, wallet, network, JSON errors (Sprint 12) + static dashboard hosting (Sprint 13a) |
+| ApiServer.java | ✅ Complete | ~420 | Javalin REST API: blocks, transactions, mining, wallet, network, JSON errors (Sprint 12) + static dashboard hosting (Sprint 13a) + contract deploy/claim/inspect endpoints (Sprint 14c) |
+
+### Contract Classes (`com.blocksmith.contract`)
+
+| Class | Status | Lines | Notes |
+|-------|--------|-------|-------|
+| ScriptOp.java | ✅ Complete | ~50 | Opcode enum: PUSH/DUP/DROP/SHA256/EQUAL(VERIFY)/VERIFY/ADD/SUB/GREATER/LESS/CHECKLOCKTIME (Sprint 14a) |
+| ScriptVM.java | ✅ Complete | ~200 | Stack machine; hashlock/timelock; never throws (malformed = false) (Sprint 14a) |
+| Contract.java | ✅ Complete | ~100 | Contract model: locking script, amount, funder, status, derived from chain (Sprint 14b) |
+| ContractStatus.java | ✅ Complete | ~12 | OPEN / CLAIMED (Sprint 14b) |
 
 ### Web Dashboard (`src/main/resources/public`)
 
@@ -148,8 +160,8 @@ Last test run: `mvn test` - All passing
 
 | Class | Status | Notes |
 |-------|--------|-------|
-| BlockSmithNode.java | ✅ Complete | Runnable node: P2P Node + ApiServer + dashboard in one process (Sprint 13a) |
-| BlockSmithDemo.java | ✅ Complete | Mining + Transactions demo |
+| BlockSmithNode.java | ✅ Complete | Runnable node: P2P Node + ApiServer + dashboard in one process (Sprint 13a). Default `mvn exec:java` target + jar main class (Sprint 14) |
+| BlockSmithDemo.java | ✅ Complete | Mining + Transactions demo (`mvn exec:java -Dexec.mainClass=com.blocksmith.BlockSmithDemo`) |
 
 ---
 
@@ -216,6 +228,10 @@ Last test run: `mvn test` - All passing
 - [x] Explorer view: blocks + network panel with polling refresh (Sprint 13b)
 - [x] Dashboard actions: create wallet, balance lookup, send tx, mine (Sprint 13c)
 - [x] API error envelopes surfaced inline in the UI (Sprint 13c)
+- [x] Stack-based script VM with hashlock/timelock opcodes; never throws (Sprint 14a)
+- [x] Contract deploy/claim on the chain, registry derived from blocks (Sprint 14b)
+- [x] Contract balance rules + script-verified claims + double-claim protection (Sprint 14b)
+- [x] Contract REST endpoints + dashboard panel (deploy/claim) (Sprint 14c)
 
 ---
 
@@ -224,7 +240,7 @@ Last test run: `mvn test` - All passing
 | Item | Value |
 |------|-------|
 | **Current Branch** | `master` |
-| **Last Commit** | Sprint 13 complete (dashboard actions merged, PR #133) |
+| **Last Commit** | Sprint 14 complete (contract endpoints merged, PR #144) |
 | **Tag** | `v1.0.0` (Phase 1) |
 | **Main Branch** | `master` |
 
@@ -238,19 +254,23 @@ _None currently._
 
 ## 📝 Notes for Next Session
 
-1. **Sprint 13 COMPLETE** - Web Dashboard
-   - All milestones 13a, 13b, 13c merged to master
-   - `BlockSmithNode` boots Node + ApiServer in one process; dashboard served
-     at `http://localhost:7070/` from `src/main/resources/public`
-   - Explorer (blocks + network, 4s polling) and actions (create wallet,
-     balance, send tx, mine) drive the Sprint 12 endpoints; API errors surface
-     inline in the UI
-   - Vanilla HTML/JS/CSS, no build step; values rendered with `textContent`
+1. **Sprint 14 COMPLETE** - Smart Contracts
+   - All milestones 14a, 14b, 14c merged to master
+   - `com.blocksmith.contract`: `ScriptVM` stack machine (hashlock/timelock,
+     never throws), `Contract`/`ContractStatus`
+   - Contracts modelled as transactions (deploy TO `CONTRACT:<id>` with a
+     locking script, claim FROM it with unlocking data); registry derived from
+     blocks so all nodes converge - no changes needed to `getBalance`
+   - REST: `POST /api/contracts`, `GET /api/contracts[/{id}]`,
+     `POST /api/contracts/{id}/claim`; dashboard Contracts panel
+   - Tooling: `mvn exec:java` now runs the node + dashboard by default; jar main
+     class is `BlockSmithNode`; demo via `-Dexec.mainClass=...BlockSmithDemo`
 
-2. **Phase 3 IN PROGRESS** - API & Interface (Sprints 12-13 done, 50%)
+2. **Phase 3 IN PROGRESS** - API & Interface (Sprints 12-14 done, 75%)
 
-3. **Next: Sprint 14** - Smart Contracts
-   - Not yet planned; scope and milestones TBD in sprint planning
+3. **Next: Sprint 15** - Multi-sig Wallets
+   - Not yet planned; M-of-N signatures, threshold signing. The Sprint 14
+     script VM is a natural foundation (a CHECKMULTISIG-style opcode)
 
 4. **Deferred / future work**
    - Gossip auto-connect to DISCOVERED peers (needs MAX_PEERS guarding)
@@ -260,9 +280,9 @@ _None currently._
    - API transactions are unsigned (educational); signature-carrying submission
      would need public-key + signature fields in the request body
    - WebSocket push for the dashboard (currently 4s polling)
-   - `pom.xml` exec/jar main class still points at `BlockSmithDemo`, not
-     `BlockSmithNode`
+   - Contract deploy uses `System.currentTimeMillis()` in the id seed; fine for
+     uniqueness but not reproducible across a re-mine
 
 ---
 
-*Last updated: 2026-07-03 | Sprint 13 Complete (Milestone 13c) - Phase 3 In Progress*
+*Last updated: 2026-07-03 | Sprint 14 Complete (Milestone 14c) - Phase 3 In Progress*

--- a/.ai/roadmap.md
+++ b/.ai/roadmap.md
@@ -28,10 +28,10 @@ Transform BlockSmith from an educational blockchain into a **fully functional di
 │  ├── Block Broadcasting                          ✅ Sprint 10       │
 │  └── Mempool Synchronization                     ✅ Sprint 11       │
 │                                                                     │
-│  PHASE 3: API & Interface (Sprint 12-15)        ██████░░░░░░ 50% ←NOW│
+│  PHASE 3: API & Interface (Sprint 12-15)        █████████░░░ 75% ←NOW│
 │  ├── REST API                                    ✅ Sprint 12       │
 │  ├── Web Dashboard                               ✅ Sprint 13       │
-│  ├── Basic Smart Contracts                       ⬜ Sprint 14       │
+│  ├── Basic Smart Contracts                       ✅ Sprint 14       │
 │  └── Multi-signature Wallets                     ⬜ Sprint 15       │
 │                                                                     │
 │  PHASE 4: Production Features (Sprint 16-19)    ░░░░░░░░░░░░ 0%     │
@@ -98,7 +98,7 @@ com.blocksmith.network/
 
 ---
 
-## 🖥️ Phase 3: API & Interface 🔄 In Progress (50%)
+## 🖥️ Phase 3: API & Interface 🔄 In Progress (75%)
 
 **Goal:** Add REST API and web dashboard for easy interaction.
 
@@ -106,21 +106,25 @@ com.blocksmith.network/
 |--------|-------|------------------|--------|
 | 12 | REST API | Javalin HTTP endpoints (blocks, tx, mine, wallet, network), JSON responses | ✅ Complete |
 | 13 | Web Dashboard | Runnable node entry point, explorer view (blocks + network), wallet/tx/mine actions, polling refresh | ✅ Complete |
-| 14 | Smart Contracts | Script interpreter, basic conditions, contract storage | ⬜ Next |
+| 14 | Smart Contracts | Stack-based script VM (hashlock/timelock), contract deploy/claim on chain, REST + dashboard panel | ✅ Complete |
 | 15 | Multi-sig Wallets | M-of-N signatures, threshold signing | ⬜ Planned |
 
-### API Endpoints (Sprint 12)
+### API Endpoints (Sprint 12 + 14)
 ```
-GET  /api/blocks              # List all blocks
-GET  /api/blocks/{index}      # Get block by index
-GET  /api/blocks/latest       # Get latest block
-POST /api/transactions        # Submit transaction
-GET  /api/transactions/{id}   # Get transaction
-GET  /api/wallet/{address}    # Get wallet balance
-POST /api/wallet/create       # Create new wallet
-POST /api/mine                # Mine pending transactions
-GET  /api/network/peers       # List connected peers
-GET  /api/network/status      # Network status
+GET  /api/blocks               # List all blocks
+GET  /api/blocks/{index}       # Get block by index
+GET  /api/blocks/latest        # Get latest block
+POST /api/transactions         # Submit transaction
+GET  /api/transactions/{id}    # Get transaction
+GET  /api/wallet/{address}     # Get wallet balance
+POST /api/wallet/create        # Create new wallet
+POST /api/mine                 # Mine pending transactions
+GET  /api/network/peers        # List connected peers
+GET  /api/network/status       # Network status
+POST /api/contracts            # Deploy a contract (Sprint 14c)
+GET  /api/contracts            # List contracts
+GET  /api/contracts/{id}       # Inspect a contract
+POST /api/contracts/{id}/claim # Claim a contract
 ```
 
 ### Technologies

--- a/.ai/sprints/sprint14/sprint-log.md
+++ b/.ai/sprints/sprint14/sprint-log.md
@@ -5,33 +5,81 @@
 | Event | Date |
 |-------|------|
 | **Sprint Start** | 2026-07-03 |
-| **Sprint End** | TBD |
+| **Sprint End** | 2026-07-03 |
 
 ---
 
-## Milestone 14a: Script engine core - Pending
+## Milestone 14a: Script engine core - Complete ✅
+
+**Issues:** #136 (VM), #137 (tests) | **PR:** #138
+
+- New `com.blocksmith.contract` package
+- `ScriptOp` - 12-opcode set: `PUSH`, `DUP`, `DROP`, `SHA256`, `EQUAL`,
+  `EQUALVERIFY`, `VERIFY`, `ADD`, `SUB`, `GREATERTHAN`, `LESSTHAN`,
+  `CHECKLOCKTIME`
+- `ScriptVM` - stack machine, early-Bitcoin execution model (unlocking +
+  locking script run once; success = truthy top of stack). **Never throws**:
+  unknown opcodes, underflow, non-numeric arithmetic, oversized scripts all
+  evaluate to false (consensus safety - a crashing script would be a DoS vector)
+- `ScriptVMTest` (21 tests): every opcode, hashlock/timelock scenarios and
+  their composition, exhaustive failure semantics
+
+## Milestone 14b: Contracts on the chain - Complete ✅
+
+**Issues:** #139 (deploy/claim), #140 (tests) | **PR:** #141
+
+- `Contract` + `ContractStatus` (OPEN/CLAIMED)
+- Contracts modelled as transactions: deploy sends TO `CONTRACT:<id>` with a
+  locking script, claim sends FROM it with unlocking data - so the existing
+  balance model debits the funder and credits the claimer with no changes to
+  `getBalance`, and gossip/mining need no special cases
+- Contract registry is **derived state**: every block-append path scans for
+  deploys/claims, so all nodes converge on identical contract state
+- `Blockchain`: `deployContract`, `claimContract`, `getContract(s)`,
+  `registerContracts`, and `addTransaction` rules (script-less transfer to a
+  contract address rejected; claim validated via `ScriptVM` at next-block
+  height); double-claim protection falls out of the pending-outgoing check
+- `ChainContractTest` (9 tests): lifecycle, both lock types, every rejection
+  path, and cross-node convergence
+
+## Milestone 14c: API + dashboard integration - Complete ✅
+
+**Issues:** #142 (endpoints + panel), #143 (tests) | **PR:** #144
+
+- `ApiServer`: `POST /api/contracts`, `GET /api/contracts[/{id}]`,
+  `POST /api/contracts/{id}/claim` - deploys/claims broadcast to peers,
+  rejections return the standard JSON error envelope
+- Dashboard Contracts panel: deploy + claim forms (a deploy hands its id to
+  the claim form), status-coloured contract cards, inline errors
+- `ApiContractsTest` (3 tests): HTTP lifecycle, list reflects deploys,
+  rejected deploy/claim/missing-fields return error envelopes
+- **Verified live** against a running node: deploy locks funds, correct
+  preimage settles, wrong preimage rejected with an error envelope
 
 ---
 
-## Milestone 14b: Contracts on the chain - Pending
+## Results
 
----
-
-## Milestone 14c: API + dashboard integration - Pending
-
----
+- **Tests:** 217 -> 220 in this sprint's final milestone; total across the
+  sprint 187 -> 220 (+21 VM, +9 chain, +3 API)
+- Programmable money end to end: lock funds behind a hashlock or timelock,
+  claim by satisfying the script, all drivable from the dashboard
+- **Tooling fix:** `mvn exec:java` now runs `BlockSmithNode` (node + dashboard)
+  by default; the demo runs via
+  `mvn exec:java -Dexec.mainClass=com.blocksmith.BlockSmithDemo`. The jar
+  manifest main class is now `BlockSmithNode`. (The old README instruction
+  `java -cp target/classes` omitted the dependency jars and did not run.)
 
 ## Notes
 
 - Third sprint of Phase 3 (API & Interface); Sprints 12-13 delivered the REST
   API and the web dashboard
 - Approach: Bitcoin-Script-style stack-based interpreter (not an Ethereum-style
-  VM) - small enough to build correctly in one sprint, fully unit-testable,
-  and historically how programmable money appeared
+  VM) - small enough to build correctly in one sprint, fully unit-testable
 - Two flagship conditions: hashlock (preimage reveals) and timelock (block
   height) - the building blocks of atomic swaps and vesting
 - New package: `com.blocksmith.contract`; no new dependency
 
 ---
 
-*Created: 2026-07-03*
+*Created: 2026-07-03 | Completed: 2026-07-03*

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ BlockSmith is a comprehensive blockchain project that goes beyond tutorials - im
 
 [![Java](https://img.shields.io/badge/Java-20+-orange.svg)](https://openjdk.org/)
 [![Maven](https://img.shields.io/badge/Maven-3.9+-blue.svg)](https://maven.apache.org/)
-[![Tests](https://img.shields.io/badge/Tests-187%20passing-brightgreen.svg)](#)
+[![Tests](https://img.shields.io/badge/Tests-220%20passing-brightgreen.svg)](#)
 [![Phase](https://img.shields.io/badge/Phase%202-In%20Progress-yellow.svg)](#)
 [![Version](https://img.shields.io/badge/Version-1.0.0-blue.svg)](#)
 
@@ -49,7 +49,7 @@ BlockSmith is a comprehensive blockchain project that goes beyond tutorials - im
   - ✅ Prune confirmed transactions from the mempool (Sprint 11b)
   - ✅ Mempool sync on connect (GET_MEMPOOL/MEMPOOL) (Sprint 11c)
 
-### Phase 3: API & Interface 🔄 In Progress (50%)
+### Phase 3: API & Interface 🔄 In Progress (75%)
 - ✅ REST API for blockchain interaction (Sprint 12)
   - ✅ Javalin server + block read endpoints (Sprint 12a)
   - ✅ Transaction submit/lookup + mining endpoints (Sprint 12b)
@@ -58,7 +58,11 @@ BlockSmith is a comprehensive blockchain project that goes beyond tutorials - im
   - ✅ Runnable node entry point + static hosting (Sprint 13a)
   - ✅ Explorer view: blocks + network, polling refresh (Sprint 13b)
   - ✅ Wallet, transaction, and mine actions in the UI (Sprint 13c)
-- 🔜 Basic smart contracts (Sprint 14)
+- ✅ Smart contracts (Sprint 14)
+  - ✅ Stack-based script VM: hashlock + timelock opcodes (Sprint 14a)
+  - ✅ Contract deploy/claim on the chain, registry derived from blocks (Sprint 14b)
+  - ✅ Contract REST endpoints + dashboard panel (Sprint 14c)
+- 🔜 Multi-signature wallets (Sprint 15)
 - 🔜 Basic smart contract support (Sprint 14)
 - 🔜 Multi-signature wallets (Sprint 15)
 
@@ -202,27 +206,27 @@ Average attempts: ~16^difficulty (~65,536 for difficulty 4)
 mvn clean compile
 ```
 
-### Run all tests (187 tests)
+### Run all tests (220 tests)
 ```bash
 mvn test
 ```
 
 ### Run a node with the web dashboard
 ```bash
-mvn -q compile
-java -cp target/classes com.blocksmith.BlockSmithNode
+mvn exec:java
 # open http://localhost:7070/
 ```
+Optional ports (P2P, API): `mvn exec:java -Dexec.args="8335 7070"`
 
-### Run the demo
+### Run the teaching demo
 ```bash
-mvn exec:java
+mvn exec:java -Dexec.mainClass=com.blocksmith.BlockSmithDemo
 ```
 
 ### Create JAR package
 ```bash
 mvn package
-java -jar target/blocksmith-1.0.0.jar
+java -jar target/blocksmith-1.0.0.jar   # starts the node + dashboard
 ```
 
 ---
@@ -266,10 +270,15 @@ BlockSmith/
 │   │   └── messages/           # Concrete message classes (incl. GetPeers/Peers)
 │   ├── api/
 │   │   └── ApiServer.java      # Javalin REST API + static dashboard hosting
+│   ├── contract/               # Smart contracts (Sprint 14)
+│   │   ├── ScriptOp.java       # Script opcode set
+│   │   ├── ScriptVM.java       # Stack-based script interpreter
+│   │   ├── Contract.java       # Contract model (locking script + funds)
+│   │   └── ContractStatus.java # OPEN / CLAIMED
 │   ├── BlockSmithNode.java     # Runnable node (P2P + API + dashboard)
-│   └── BlockSmithDemo.java     # Main demo application
+│   └── BlockSmithDemo.java     # Teaching demo application
 ├── src/main/resources/public/  # Web dashboard (index.html, app.js, style.css)
-├── src/test/java/              # 187 unit tests
+├── src/test/java/              # 220 unit tests
 ├── data/                       # Blockchain persistence (JSON)
 ├── pom.xml                     # Maven configuration
 └── README.md
@@ -309,7 +318,10 @@ BlockSmith/
 | ApiStaticHostingTest | 3 | Dashboard shell + static assets alongside the API |
 | ApiExplorerTest | 2 | Explorer mount points + block JSON shape |
 | ApiDashboardActionsTest | 2 | Dashboard action chain end to end |
-| **Total** | **187** | All passing ✅ |
+| ScriptVMTest | 21 | Script opcodes, hashlock/timelock, failure semantics |
+| ChainContractTest | 9 | Contract deploy/claim, timelock, double-claim, convergence |
+| ApiContractsTest | 3 | Contract lifecycle over HTTP + error envelopes |
+| **Total** | **220** | All passing ✅ |
 
 ---
 
@@ -363,12 +375,12 @@ BlockSmith/
 | Sprint 10 | Block Broadcasting | ✅ Complete (10a, 10b, 10c, 10d) |
 | Sprint 11 | Mempool Sync | ✅ Complete (11a, 11b, 11c) |
 
-### Phase 3: API & Interface 🔄 In Progress (50%)
+### Phase 3: API & Interface 🔄 In Progress (75%)
 | Sprint | Title | Status |
 |--------|-------|--------|
 | Sprint 12 | REST API | ✅ Complete (12a, 12b, 12c) |
 | Sprint 13 | Web Dashboard | ✅ Complete (13a, 13b, 13c) |
-| Sprint 14 | Smart Contracts | ⬜ Planned |
+| Sprint 14 | Smart Contracts | ✅ Complete (14a, 14b, 14c) |
 | Sprint 15 | Multi-sig Wallets | ⬜ Planned |
 
 ### Phase 4: Production
@@ -398,4 +410,4 @@ This project is for educational purposes.
 
 ---
 
-*Last updated: 2026-07-03 | Phase 3 In Progress (Sprint 13 - Web Dashboard Complete)*
+*Last updated: 2026-07-03 | Phase 3 In Progress (Sprint 14 - Smart Contracts Complete)*

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,10 @@
         <junit.version>5.10.1</junit.version>
         <gson.version>2.10.1</gson.version>
         <javalin.version>6.3.0</javalin.version>
+        <!-- Primary entry point: the runnable node + web dashboard.
+             Override to run the teaching demo:
+             mvn exec:java -Dexec.mainClass=com.blocksmith.BlockSmithDemo -->
+        <exec.mainClass>com.blocksmith.BlockSmithNode</exec.mainClass>
     </properties>
 
     <dependencies>
@@ -65,18 +69,19 @@
                 <configuration>
                     <archive>
                         <manifest>
-                            <mainClass>com.blocksmith.BlockSmithDemo</mainClass>
+                            <mainClass>com.blocksmith.BlockSmithNode</mainClass>
                         </manifest>
                     </archive>
                 </configuration>
             </plugin>
-            <!-- Run with: mvn exec:java -->
+            <!-- Run the node + dashboard with: mvn exec:java
+                 Run the demo with: mvn exec:java -Dexec.mainClass=com.blocksmith.BlockSmithDemo -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>3.1.0</version>
                 <configuration>
-                    <mainClass>com.blocksmith.BlockSmithDemo</mainClass>
+                    <mainClass>${exec.mainClass}</mainClass>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Brings all docs in line with Sprint 14 (Smart Contracts) complete, and fixes the node run command.

## Docs
- **STATUS.md** — Sprint 14 complete (14a-14c), Phase 3 at 75%, test table -> **220**, new `com.blocksmith.contract` class section, contract features, next-session notes point at Sprint 15
- **README.md** — badge + test table -> 220, Phase 3 progress, contract endpoints/tree, corrected run commands
- **roadmap.md** — Phase 3 at 75%, Sprint 14 ✅, contract endpoints added to the API list
- **ONBOARDING.md** — quick-ref, tree (contract package), Sprint 14 summary, test table -> 220, deep-dive links -> sprint14
- **ARCHITECTURE.md** — corrected demo run command
- **sprint14/sprint-log.md** — full milestone log (14a #138, 14b #141, 14c #144)

## Run-command fix (pom.xml)
The old README said `java -cp target/classes com.blocksmith.BlockSmithNode` — that **omits the Gson/Javalin jars** and dies with `NoClassDefFoundError` (confirmed). Fixed so the node is the primary, dependency-complete entry point:
- `mvn exec:java` now runs **BlockSmithNode** (node + dashboard) by default — verified it boots and `/api/network/status` responds
- jar manifest main class is now `BlockSmithNode`, so `java -jar` starts the node
- the demo runs via `mvn exec:java -Dexec.mainClass=com.blocksmith.BlockSmithDemo`

**Full suite: 220 passing** (pom change verified not to disturb the test run).

No product code changes.