### PR TITLE
docs: Sprint 15 planning (Multi-signature Wallets)

### DIFF
--- a/.ai/sprints/sprint15/github-issues.md
+++ b/.ai/sprints/sprint15/github-issues.md
@@ -1,0 +1,159 @@
+# Sprint 15: GitHub Issues
+
+> Copy each issue to GitHub. Actual issue numbers are assigned on creation
+> (PRs consume the same number space, so they will not be contiguous).
+
+---
+
+## Milestone 15a: Signature opcodes in the VM
+
+---
+
+### Add CHECKSIG and CHECKMULTISIG to the script VM
+
+**Labels:** `sprint-15`, `milestone-15a`, `enhancement`
+
+**Description:**
+
+- `SignatureUtil`: ECDSA sign/verify (secp256r1, SHA256withECDSA) + hex
+  encode/decode for public keys and signatures
+- `ScriptVM.execute(...)` gains an optional sighash (the message a spender
+  authorizes); ordinary scripts ignore it
+- `CHECKSIG`: pop pubkey + signature, push 1 if valid for the sighash else 0
+- `CHECKMULTISIG`: pop N, N pubkeys, M, M signatures; push 1 iff at least M
+  signatures are valid under distinct keys (ordered, Bitcoin-style)
+- Never-throws preserved: malformed keys/sigs/counts evaluate to false
+
+**Acceptance Criteria:**
+- [ ] CHECKSIG true only for a valid signature over the sighash
+- [ ] CHECKMULTISIG true for M-of-N, false below threshold
+- [ ] Malformed input never throws
+- [ ] Compiles with `mvn compile`
+
+---
+
+### Tests for the signature opcodes
+
+**Labels:** `sprint-15`, `milestone-15a`, `test`
+
+**Description:**
+
+**Test Cases:**
+1. `checkSig_trueForValidSignature_falseOtherwise`
+2. `checkMultiSig_twoOfThree_valid`
+3. `checkMultiSig_insufficientSignatures_false`
+4. `checkMultiSig_wrongKeySignature_false`
+5. `checkMultiSig_duplicateSignatureNotDoubleCounted`
+6. Malformed hex / count mismatch -> false, no exception
+
+**Acceptance Criteria:**
+- [ ] Tests added and passing
+- [ ] All existing tests still passing
+- [ ] `mvn test` green
+
+---
+
+## Milestone 15b: Multisig contracts (M-of-N)
+
+---
+
+### Multisig wallet + signature-locked contracts
+
+**Labels:** `sprint-15`, `milestone-15b`, `enhancement`
+
+**Description:**
+
+- `MultiSigWallet`: N member public keys + threshold M; builds the
+  `CHECKMULTISIG` locking script; derives a stable multisig address
+- Claim sighash: `SHA256(contractId + claimer + amount)` - binds a signature
+  to one claim so it cannot be replayed to a different claimer
+- Claim path feeds the claim's sighash to the VM so `CHECKMULTISIG` can verify
+  the presented signatures; unlocking data carries the M signatures
+- Reuses Sprint 14 contract deploy/claim/registry unchanged
+
+**Acceptance Criteria:**
+- [ ] 2-of-3 deploy then claim with 2 valid signatures moves the funds
+- [ ] Claim with fewer than M valid signatures is rejected
+- [ ] A signature for one claimer cannot be replayed for another
+- [ ] Compiles with `mvn compile`
+
+---
+
+### Tests for multisig contracts
+
+**Labels:** `sprint-15`, `milestone-15b`, `test`
+
+**Description:**
+
+**Test Cases:**
+1. `twoOfThree_claimWithTwoSignatures_creditsClaimer`
+2. `claimWithOneSignature_rejected`
+3. `claimWithWrongKeySignature_rejected`
+4. `signatureReplayToDifferentClaimer_rejected`
+5. `externalBlocks_buildSameMultisigState`
+
+**Acceptance Criteria:**
+- [ ] Tests added and passing
+- [ ] All existing tests still passing
+- [ ] `mvn test` green
+
+---
+
+## Milestone 15c: API + dashboard integration
+
+---
+
+### Multisig endpoints + dashboard panel
+
+**Labels:** `sprint-15`, `milestone-15c`, `enhancement`
+
+**Description:**
+
+- `POST /api/multisig/create` - create an M-of-N wallet; return address,
+  member public keys, and the locking script
+- Claim assembly endpoint: produce/submit a multisig claim with the collected
+  member signatures (server-side signing convenience, flagged educational)
+- Dashboard panel: create a multisig, show members/threshold, claim from it;
+  errors surfaced inline
+- JSON error envelope for rejected creates/claims (Sprint 12 style)
+
+**Acceptance Criteria:**
+- [ ] A user can create a multisig and claim from it in the UI
+- [ ] Errors are shown to the user
+- [ ] Compiles with `mvn compile`
+
+---
+
+### Tests for multisig endpoints
+
+**Labels:** `sprint-15`, `milestone-15c`, `test`
+
+**Description:**
+
+**Test Cases:**
+1. `multisigLifecycle_overHttp` (create -> deploy -> claim -> balances move)
+2. `rejectedMultisigClaim_returnsErrorEnvelope`
+
+**Acceptance Criteria:**
+- [ ] Tests added and passing
+- [ ] All existing tests still passing
+- [ ] `mvn test` green
+
+---
+
+## Summary
+
+| Milestone | Issues | Tests |
+|-----------|--------|-------|
+| 15a: Signature opcodes | 2 | ~10 tests |
+| 15b: Multisig contracts | 2 | ~5 tests |
+| 15c: API + dashboard | 2 | ~2 tests |
+| **Total** | **6 issues** | **~17 tests** |
+
+> 15a is the test-heavy milestone: signature verification is pure crypto logic,
+> so it gets exhaustive unit coverage. 15c follows the Sprint 13-14 pattern -
+> the browser UI is verified by running it; automated tests cover the server.
+
+---
+
+*Created: 2026-07-03 | Sprint 15 Planning*

--- a/.ai/sprints/sprint15/sprint-log.md
+++ b/.ai/sprints/sprint15/sprint-log.md
@@ -1,0 +1,40 @@
+# Sprint 15: Multi-signature Wallets - Log
+
+## Sprint Timeline
+
+| Event | Date |
+|-------|------|
+| **Sprint Start** | 2026-07-03 |
+| **Sprint End** | TBD |
+
+---
+
+## Milestone 15a: Signature opcodes in the VM - Pending
+
+---
+
+## Milestone 15b: Multisig contracts (M-of-N) - Pending
+
+---
+
+## Milestone 15c: API + dashboard integration - Pending
+
+---
+
+## Notes
+
+- Final sprint of Phase 3 (API & Interface); completes the phase and the
+  wallet/contract/VM arc
+- Approach: multisig built ON the Sprint 14 script VM - `CHECKSIG` /
+  `CHECKMULTISIG` opcodes, and an M-of-N multisig is a contract with a
+  signature-checking locking script (Bitcoin P2SH-style)
+- The one new crypto piece is the sighash: `SHA256(contractId + claimer +
+  amount)`, which binds a signature to a single claim (replay safety)
+- Reuses Sprint 5 `Wallet` primitives (ECDSA secp256r1) and Sprint 14 contract
+  machinery; no new dependency
+- Signing is a server-side convenience for the demo (flagged educational),
+  consistent with the unsigned transaction endpoints from Sprint 12
+
+---
+
+*Created: 2026-07-03*

--- a/.ai/sprints/sprint15/sprint-plan.md
+++ b/.ai/sprints/sprint15/sprint-plan.md
@@ -1,0 +1,153 @@
+# Sprint 15: Multi-signature Wallets
+
+## Sprint Info
+
+| Field | Value |
+|-------|-------|
+| **Sprint** | 15 |
+| **Title** | Multi-signature Wallets |
+| **Phase** | Phase 3: API & Interface |
+| **Status** | Planning |
+| **Depends On** | Sprint 14 Complete (Smart Contracts / script VM) |
+
+> **Approach (recommended):** build multisig ON the Sprint 14 script VM. Add
+> signature-checking opcodes (`CHECKSIG`, `CHECKMULTISIG`); an M-of-N multisig
+> is then just a **contract** whose locking script is a `CHECKMULTISIG`, reusing
+> all of Sprint 14's deploy/claim/registry machinery. This is exactly how
+> Bitcoin does multisig (P2SH). The one genuinely new piece is a **sighash**:
+> the message a spender signs to authorize a specific claim, bound to the
+> claimer and amount so a signature cannot be replayed elsewhere.
+
+---
+
+## Goal
+
+Let funds require **M of N** signatures to move, instead of a single key. A
+2-of-3 escrow, a shared treasury, a backup-key setup - all expressed as a
+multisig contract. The capstone of Phase 3: it unifies the wallet (Sprint 5),
+the contract model (Sprint 14), and the script VM into one feature, and drives
+end to end from the dashboard.
+
+---
+
+## Milestones
+
+| Milestone | Title | Branch | Status |
+|-----------|-------|--------|--------|
+| **15a** | Signature opcodes in the VM | `sprint15a/sig-opcodes` | Pending |
+| **15b** | Multisig contracts (M-of-N) | `sprint15b/multisig-contracts` | Pending |
+| **15c** | API + dashboard integration | `sprint15c/multisig-api` | Pending |
+
+---
+
+## Milestone 15a: Signature opcodes in the VM
+
+### Deliverables
+
+- [ ] `SignatureUtil`: ECDSA sign/verify helpers (secp256r1, SHA256withECDSA)
+      plus hex encode/decode for public keys and signatures (the VM works on
+      string data elements, so keys/sigs travel as hex)
+- [ ] `ScriptVM.execute(...)` gains an optional **sighash** (the message the
+      spender authorizes); ordinary scripts pass it as empty/ignored
+- [ ] `CHECKSIG`: pop a public key and a signature, push 1 if the signature is
+      valid for the sighash under that key, else 0
+- [ ] `CHECKMULTISIG`: pop N, N public keys, M, and M signatures; push 1 iff at
+      least M signatures are valid under distinct keys (ordered, Bitcoin-style)
+- [ ] Never-throws preserved: malformed keys/sigs/counts evaluate to false
+- [ ] Tests: single-sig valid/invalid, 2-of-3 valid, insufficient signatures,
+      wrong-key signature, duplicate signature not double-counted, malformed
+      hex, count mismatches
+
+### Why this is first
+
+The crypto is pure logic and belongs in the VM. Building and testing it in
+isolation means 15b only wires it to contracts.
+
+---
+
+## Milestone 15b: Multisig contracts (M-of-N)
+
+### Deliverables
+
+- [ ] `MultiSigWallet`: holds N member public keys and a threshold M; builds
+      the `CHECKMULTISIG` locking script; derives a stable multisig address
+- [ ] A **sighash** for claims: deterministic digest binding the claim to its
+      contract, claimer, and amount, so a signature authorizes exactly one
+      claim and cannot be replayed to a different claimer
+- [ ] Claim path: when a claim targets a multisig contract, feed the claim's
+      sighash to the VM so `CHECKMULTISIG` can verify the presented signatures
+- [ ] Members sign the sighash; the unlocking data carries the M signatures
+- [ ] Tests: 2-of-3 deploy/claim moves funds, insufficient signatures rejected,
+      wrong-key signature rejected, signature-replay-to-different-claimer
+      rejected, cross-node convergence
+
+### Note
+
+This reuses Sprint 14's contract deploy/claim/registry unchanged - a multisig
+is a contract with a signature-checking lock. Only the sighash and the claim's
+signature-collection are new.
+
+---
+
+## Milestone 15c: API + dashboard integration
+
+### Deliverables
+
+- [ ] `POST /api/multisig/create` - create an M-of-N wallet, return address +
+      member public keys + the locking script
+- [ ] Claim assembly: an endpoint to produce/submit a multisig claim with the
+      collected member signatures
+- [ ] Dashboard panel: create a multisig, show its members/threshold, and
+      claim from it; errors surfaced inline
+- [ ] Tests (server-side): HTTP multisig lifecycle + rejection envelopes
+
+### Scope note
+
+Signing normally happens client-side with private keys the node never sees.
+For this educational build the node offers a **signing convenience** (the
+member keys are generated and used server-side), clearly flagged - consistent
+with the already-unsigned transaction endpoints from Sprint 12. A production
+design would sign in the wallet and submit only signatures.
+
+---
+
+## Theory: M-of-N is just a script
+
+```
+Single-sig lock:   <pubkey> CHECKSIG
+                   unlock with one signature over the sighash
+
+Multisig lock:     M <pub1> <pub2> <pub3> N CHECKMULTISIG      (e.g. 2 of 3)
+                   unlock with any 2 valid signatures over the sighash
+
+The sighash binds the signature to THIS claim:
+   sighash = SHA256(contractId + claimer + amount)
+
+So a 2-of-3 signature set authorizing "pay Bob" cannot be replayed to pay Carol
+- the message signed is different. This is the same reason Bitcoin signs a
+transaction digest, not a fixed string.
+```
+
+---
+
+## Dependencies
+
+- Sprint 14 script VM (`ScriptVM`, contract deploy/claim/registry)
+- Sprint 5 `Wallet` (ECDSA secp256r1, SHA256withECDSA) - the same primitives
+- `HashUtil` for the sighash
+- No new dependency
+
+---
+
+## Open decisions
+
+- **Multisig as a contract script** (recommended) vs a standalone multi-sig
+  transaction type - the script route reuses Sprint 14 wholesale
+- **Sighash contents**: contractId + claimer + amount (recommended) - minimal
+  and replay-safe
+- **Signing location**: server-side convenience for the demo (recommended,
+  flagged educational) vs client-side only (correct but needs a JS crypto stack)
+
+---
+
+*Created: 2026-07-03 | Sprint 15 Planning*


### PR DESCRIPTION
Planning docs for Sprint 15 - Multi-signature Wallets, the **final sprint of Phase 3**.

## Approach
Build multisig **on the Sprint 14 script VM**. Add `CHECKSIG` / `CHECKMULTISIG` opcodes; an M-of-N multisig is then just a **contract** whose locking script is a `CHECKMULTISIG`, reusing Sprint 14's deploy/claim/registry wholesale. This is how Bitcoin does multisig (P2SH). The one new crypto piece is a **sighash** - `SHA256(contractId + claimer + amount)` - which binds a signature to a single claim so it can't be replayed to a different claimer.

## Milestones
| Milestone | Title | Branch |
|-----------|-------|--------|
| 15a | Signature opcodes in the VM (`CHECKSIG`/`CHECKMULTISIG`, `SignatureUtil`, exhaustive tests) | `sprint15a/sig-opcodes` |
| 15b | Multisig contracts (`MultiSigWallet`, sighash, M-of-N claim path) | `sprint15b/multisig-contracts` |
| 15c | API + dashboard (create multisig, claim, panel) | `sprint15c/multisig-api` |

## Theory
```
Multisig lock:  M <pub1> <pub2> <pub3> N CHECKMULTISIG   (e.g. 2 of 3)
unlock:         any 2 valid signatures over sighash = SHA256(contractId + claimer + amount)
```
A 2-of-3 signature set authorizing "pay Bob" cannot be replayed to pay Carol - the signed message differs.

## Files
- `.ai/sprints/sprint15/sprint-plan.md` - goal, milestones, theory, open decisions
- `.ai/sprints/sprint15/github-issues.md` - 6 issues (~17 tests)
- `.ai/sprints/sprint15/sprint-log.md` - log skeleton

Grounded in the existing crypto: ECDSA secp256r1 / SHA256withECDSA (Sprint 5 `Wallet`) and the Sprint 14 contract machinery. No new dependency. No code changes.