### PR TITLE
Sprint 15a: Signature opcodes in the script VM (CHECKSIG/CHECKMULTISIG)

### DIFF
--- a/.ai/sprints/sprint15/sprint-log.md
+++ b/.ai/sprints/sprint15/sprint-log.md
@@ -9,7 +9,22 @@
 
 ---
 
-## Milestone 15a: Signature opcodes in the VM - Pending
+## Milestone 15a: Signature opcodes in the VM - Complete
+
+- `SignatureUtil` added: ECDSA sign/verify (secp256r1, SHA256withECDSA) with
+  hex encode/decode for public keys (X.509) and signatures (DER). `verify`
+  never throws - malformed input is "not valid" (false), consistent with the
+  VM's consensus-safety rule.
+- `ScriptVM.execute(...)` gained a sighash overload; the existing 3-arg and
+  2-arg forms delegate with an empty sighash, so every Sprint 14 call site and
+  test is unchanged (signature scripts simply fail without a sighash context).
+- `CHECKSIG` and `CHECKMULTISIG` opcodes added. Multisig layout is Bitcoin's
+  bare form `<sigs> M <pubkeys> N CHECKMULTISIG`; matching is ordered and
+  distinct-key, so a duplicate signature cannot satisfy two slots.
+- 6 new tests in `ScriptVMTest` (valid single-sig, 2-of-3, insufficient,
+  wrong-key, duplicate-not-double-counted, malformed-never-throws). Suite:
+  220 -> 226, all green.
+- Issues #147 (opcodes), #148 (tests).
 
 ---
 

--- a/src/main/java/com/blocksmith/contract/ScriptOp.java
+++ b/src/main/java/com/blocksmith/contract/ScriptOp.java
@@ -33,6 +33,13 @@ package com.blocksmith.contract;
  * CONTRACT:
  * - CHECKLOCKTIME Pops a height N; pushes 1 if the current block height
  *                 is >= N else 0 (the timelock building block)
+ *
+ * SIGNATURES (Sprint 15):
+ * - CHECKSIG      Pops a public key and a signature; pushes 1 if the signature
+ *                 is valid for the sighash under that key else 0
+ * - CHECKMULTISIG Pops N, N public keys, M, and M signatures; pushes 1 iff at
+ *                 least M signatures are valid under distinct keys (ordered).
+ *                 Layout: {@code <sigs> M <pubkeys> N CHECKMULTISIG}
  */
 public enum ScriptOp {
     PUSH,
@@ -46,5 +53,7 @@ public enum ScriptOp {
     SUB,
     GREATERTHAN,
     LESSTHAN,
-    CHECKLOCKTIME
+    CHECKLOCKTIME,
+    CHECKSIG,
+    CHECKMULTISIG
 }

--- a/src/main/java/com/blocksmith/contract/ScriptVM.java
+++ b/src/main/java/com/blocksmith/contract/ScriptVM.java
@@ -4,6 +4,7 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 
 import com.blocksmith.util.HashUtil;
+import com.blocksmith.util.SignatureUtil;
 
 /**
  * THEORY: A stack-based virtual machine for contract scripts.
@@ -47,12 +48,16 @@ public class ScriptVM {
     /** Upper bound on a single data element's length (characters). */
     public static final int MAX_ELEMENT_LENGTH = 520;
 
+    /** Upper bound on the N of an M-of-N CHECKMULTISIG. */
+    public static final int MAX_KEYS = 20;
+
     /** Canonical truthy/falsy values pushed by comparison opcodes. */
     private static final String TRUE = "1";
     private static final String FALSE = "0";
 
     /**
-     * Runs an unlocking script concatenated with a locking script.
+     * Runs an unlocking script concatenated with a locking script, with no
+     * signature context (scripts that use CHECKSIG/CHECKMULTISIG will fail).
      *
      * @param unlockingScript The claimer's data (may be empty or null)
      * @param lockingScript The contract's lock
@@ -60,9 +65,34 @@ public class ScriptVM {
      * @return true if the combined script finishes with a truthy top of stack
      */
     public boolean execute(String unlockingScript, String lockingScript, long blockHeight) {
+        return execute(unlockingScript, lockingScript, blockHeight, "");
+    }
+
+    /**
+     * Runs an unlocking script concatenated with a locking script, providing a
+     * sighash for signature opcodes.
+     *
+     * @param unlockingScript The claimer's data (may be empty or null)
+     * @param lockingScript The contract's lock
+     * @param blockHeight Current chain height, for CHECKLOCKTIME
+     * @param sighash The message a spender authorizes, for CHECKSIG/CHECKMULTISIG
+     * @return true if the combined script finishes with a truthy top of stack
+     */
+    public boolean execute(String unlockingScript, String lockingScript, long blockHeight, String sighash) {
         String unlocking = unlockingScript == null ? "" : unlockingScript;
         String locking = lockingScript == null ? "" : lockingScript;
-        return execute(unlocking + " " + locking, blockHeight);
+        return execute(unlocking + " " + locking, blockHeight, sighash);
+    }
+
+    /**
+     * Runs a single script against a fresh stack, with no signature context.
+     *
+     * @param script Whitespace-separated tokens
+     * @param blockHeight Current chain height, for CHECKLOCKTIME
+     * @return true if execution finishes with a truthy top of stack
+     */
+    public boolean execute(String script, long blockHeight) {
+        return execute(script, blockHeight, "");
     }
 
     /**
@@ -70,14 +100,16 @@ public class ScriptVM {
      *
      * @param script Whitespace-separated tokens
      * @param blockHeight Current chain height, for CHECKLOCKTIME
+     * @param sighash The message a spender authorizes, for CHECKSIG/CHECKMULTISIG
      * @return true if execution finishes with a truthy top of stack
      */
-    public boolean execute(String script, long blockHeight) {
+    public boolean execute(String script, long blockHeight, String sighash) {
         if (script == null || script.isBlank()) return false;
 
         String[] tokens = script.trim().split("\\s+");
         if (tokens.length > MAX_SCRIPT_TOKENS) return false;
 
+        String message = sighash == null ? "" : sighash;
         Deque<String> stack = new ArrayDeque<>();
         try {
             for (int i = 0; i < tokens.length; i++) {
@@ -94,7 +126,7 @@ public class ScriptVM {
                     continue;
                 }
 
-                if (!apply(op, stack, blockHeight)) return false;
+                if (!apply(op, stack, blockHeight, message)) return false;
             }
         } catch (RuntimeException e) {
             // Defense in depth: no script may crash the node.
@@ -107,7 +139,7 @@ public class ScriptVM {
     // ===== OPCODE EXECUTION =====
 
     /** Applies one non-PUSH opcode. Returns false to fail the script. */
-    private boolean apply(ScriptOp op, Deque<String> stack, long blockHeight) {
+    private boolean apply(ScriptOp op, Deque<String> stack, long blockHeight, String sighash) {
         switch (op) {
             case DUP: {
                 if (stack.isEmpty() || stack.size() >= MAX_STACK_SIZE) return false;
@@ -162,9 +194,72 @@ public class ScriptVM {
                 stack.push(blockHeight >= required ? TRUE : FALSE);
                 return true;
             }
+            case CHECKSIG: {
+                // Stack (top -> bottom): pubkey, signature
+                if (stack.size() < 2) return false;
+                String pubKey = stack.pop();
+                String signature = stack.pop();
+                stack.push(SignatureUtil.verify(pubKey, signature, sighash) ? TRUE : FALSE);
+                return true;
+            }
+            case CHECKMULTISIG:
+                return applyCheckMultiSig(stack, sighash);
             default:
                 return false;
         }
+    }
+
+    /**
+     * Applies CHECKMULTISIG. Stack layout, top to bottom:
+     *
+     *   N, pubN, ..., pub1, M, sigM, ..., sig1
+     *
+     * i.e. the script reads {@code <sigs> M <pubkeys> N CHECKMULTISIG}, exactly
+     * as Bitcoin lays out a bare multisig. Pushes 1 iff all M signatures verify
+     * against DISTINCT public keys scanned left to right (so the signatures must
+     * be supplied in the same order as their keys, and a duplicate signature
+     * cannot satisfy two slots). Any malformed count or shortfall pushes 0.
+     */
+    private boolean applyCheckMultiSig(Deque<String> stack, String sighash) {
+        // N: number of public keys
+        if (stack.isEmpty()) return false;
+        Long n = parseNumber(stack.pop());
+        if (n == null || n < 1 || n > MAX_KEYS) return false;
+        int keyCount = n.intValue();
+
+        if (stack.size() < keyCount) return false;
+        String[] pubKeys = new String[keyCount];
+        // pubN is on top; store so pubKeys[0] is the first key pushed (pub1).
+        for (int k = keyCount - 1; k >= 0; k--) pubKeys[k] = stack.pop();
+
+        // M: required number of signatures
+        if (stack.isEmpty()) return false;
+        Long m = parseNumber(stack.pop());
+        if (m == null || m < 1 || m > keyCount) return false;
+        int sigCount = m.intValue();
+
+        if (stack.size() < sigCount) return false;
+        String[] sigs = new String[sigCount];
+        // sigM is on top; store so sigs[0] is the first signature pushed (sig1).
+        for (int s = sigCount - 1; s >= 0; s--) sigs[s] = stack.pop();
+
+        // Ordered matching: walk keys left to right, consuming one per matched
+        // signature. Each key is used at most once (distinct keys), and a later
+        // signature can only match a later key (Bitcoin-style ordering).
+        int keyIndex = 0;
+        int matched = 0;
+        for (int s = 0; s < sigCount; s++) {
+            while (keyIndex < keyCount
+                    && !SignatureUtil.verify(pubKeys[keyIndex], sigs[s], sighash)) {
+                keyIndex++;
+            }
+            if (keyIndex >= keyCount) break; // ran out of keys; this sig is unmatched
+            matched++;
+            keyIndex++;
+        }
+
+        stack.push(matched == sigCount ? TRUE : FALSE);
+        return true;
     }
 
     // ===== HELPERS =====

--- a/src/main/java/com/blocksmith/util/SignatureUtil.java
+++ b/src/main/java/com/blocksmith/util/SignatureUtil.java
@@ -1,0 +1,130 @@
+package com.blocksmith.util;
+
+import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.security.spec.X509EncodedKeySpec;
+
+/**
+ * THEORY: ECDSA signing/verification helpers for the script VM.
+ *
+ * The wallet (Sprint 5) signs whole transactions with SHA256withECDSA on the
+ * secp256r1 curve. Multisig needs the same primitive at a finer grain: sign an
+ * arbitrary message (a "sighash") and verify a signature against a public key.
+ *
+ * WHY HEX? The script VM operates on string stack elements, so public keys and
+ * signatures must travel as text. We encode the raw bytes as lowercase hex:
+ * a public key is its X.509 (SubjectPublicKeyInfo) encoding, a signature is the
+ * DER-encoded ECDSA output - exactly the bytes the JCA produces and consumes.
+ *
+ * NEVER-THROWS ON VERIFY: verification is reached from inside the VM, which is
+ * consensus-critical and must never crash. A malformed key, a malformed
+ * signature, or a bad hex string is simply "not a valid signature" (false),
+ * never an exception. Signing, by contrast, is a local wallet operation and may
+ * throw - a broken key there is a programming error, not untrusted input.
+ */
+public final class SignatureUtil {
+
+    private static final char[] HEX_ARRAY = "0123456789abcdef".toCharArray();
+
+    private SignatureUtil() {
+        throw new UnsupportedOperationException("Utility class - cannot be instantiated");
+    }
+
+    /**
+     * Signs a message with a private key (SHA256withECDSA) and returns the
+     * signature as a hex string.
+     *
+     * @param privateKey The signer's private key
+     * @param message    The message to authorize (e.g. a claim's sighash)
+     * @return The DER signature, hex-encoded
+     * @throws RuntimeException if signing fails (a local key error)
+     */
+    public static String sign(PrivateKey privateKey, String message) {
+        try {
+            Signature ecdsa = Signature.getInstance("SHA256withECDSA");
+            ecdsa.initSign(privateKey);
+            ecdsa.update(message.getBytes(StandardCharsets.UTF_8));
+            return bytesToHex(ecdsa.sign());
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to sign message", e);
+        }
+    }
+
+    /**
+     * Verifies a hex signature against a hex public key over a message.
+     *
+     * Consensus-safe: returns false for any malformed input rather than
+     * throwing, so a bad script element can never crash a node.
+     *
+     * @param publicKeyHex The signer's public key, hex-encoded (X.509)
+     * @param signatureHex The signature, hex-encoded (DER)
+     * @param message      The message that was supposedly signed
+     * @return true iff the signature is valid for the message under the key
+     */
+    public static boolean verify(String publicKeyHex, String signatureHex, String message) {
+        try {
+            PublicKey publicKey = hexToPublicKey(publicKeyHex);
+            Signature ecdsa = Signature.getInstance("SHA256withECDSA");
+            ecdsa.initVerify(publicKey);
+            ecdsa.update(message.getBytes(StandardCharsets.UTF_8));
+            return ecdsa.verify(hexToBytes(signatureHex));
+        } catch (Exception e) {
+            // Malformed key/signature/hex is "not valid", never a crash.
+            return false;
+        }
+    }
+
+    /**
+     * Encodes a public key as a hex string (its X.509 encoding). Safe to share.
+     */
+    public static String publicKeyToHex(PublicKey publicKey) {
+        return bytesToHex(publicKey.getEncoded());
+    }
+
+    /**
+     * Reconstructs a public key from its hex (X.509) encoding.
+     *
+     * @throws Exception if the hex or key encoding is invalid
+     */
+    public static PublicKey hexToPublicKey(String publicKeyHex) throws Exception {
+        byte[] encoded = hexToBytes(publicKeyHex);
+        KeyFactory keyFactory = KeyFactory.getInstance("EC");
+        return keyFactory.generatePublic(new X509EncodedKeySpec(encoded));
+    }
+
+    /** Converts a byte array to a lowercase hex string. */
+    public static String bytesToHex(byte[] bytes) {
+        char[] hexChars = new char[bytes.length * 2];
+        for (int i = 0; i < bytes.length; i++) {
+            int v = bytes[i] & 0xFF;
+            hexChars[i * 2] = HEX_ARRAY[v >>> 4];
+            hexChars[i * 2 + 1] = HEX_ARRAY[v & 0x0F];
+        }
+        return new String(hexChars);
+    }
+
+    /**
+     * Converts a hex string to bytes.
+     *
+     * @throws IllegalArgumentException if the length is odd or a character is
+     *         not a hex digit (caught by {@link #verify} to yield false)
+     */
+    public static byte[] hexToBytes(String hex) {
+        if (hex == null || hex.length() % 2 != 0) {
+            throw new IllegalArgumentException("Invalid hex string");
+        }
+        byte[] out = new byte[hex.length() / 2];
+        for (int i = 0; i < out.length; i++) {
+            int hi = Character.digit(hex.charAt(i * 2), 16);
+            int lo = Character.digit(hex.charAt(i * 2 + 1), 16);
+            if (hi < 0 || lo < 0) {
+                throw new IllegalArgumentException("Invalid hex digit");
+            }
+            out[i] = (byte) ((hi << 4) | lo);
+        }
+        return out;
+    }
+}

--- a/src/test/java/com/blocksmith/contract/ScriptVMTest.java
+++ b/src/test/java/com/blocksmith/contract/ScriptVMTest.java
@@ -6,6 +6,12 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import com.blocksmith.util.HashUtil;
+import com.blocksmith.util.SignatureUtil;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PublicKey;
+import java.security.spec.ECGenParameterSpec;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -228,6 +234,131 @@ class ScriptVMTest {
         @DisplayName("CHECKLOCKTIME with non-numeric height fails the script")
         void checkLockTime_nonNumeric_fails() {
             assertFalse(vm.execute("PUSH soon CHECKLOCKTIME", 0));
+        }
+    }
+
+    // ===== SIGNATURE OPCODES (Sprint 15a) =====
+
+    @Nested
+    @DisplayName("Signature opcodes - CHECKSIG and CHECKMULTISIG")
+    class SignatureOpcodes {
+
+        /** The message a claim authorizes; the VM verifies signatures over it. */
+        private final String sighash = "claim:contract-1:0xbob:100";
+
+        @Test
+        @DisplayName("CHECKSIG: true only for a valid signature over the sighash")
+        void checkSig_trueForValidSignature_falseOtherwise() {
+            KeyPair kp = newKeyPair();
+            String pubKey = SignatureUtil.publicKeyToHex(kp.getPublic());
+            String sig = SignatureUtil.sign(kp.getPrivate(), sighash);
+            String locking = "PUSH " + pubKey + " CHECKSIG";
+
+            // Valid signature over the sighash -> true.
+            assertTrue(vm.execute("PUSH " + sig, locking, 0, sighash));
+
+            // The same signature against a different sighash -> false (replay-safe).
+            assertFalse(vm.execute("PUSH " + sig, locking, 0, "other-message"));
+
+            // A signature from a different key -> false.
+            String wrongSig = SignatureUtil.sign(newKeyPair().getPrivate(), sighash);
+            assertFalse(vm.execute("PUSH " + wrongSig, locking, 0, sighash));
+
+            // No sighash context (the 3-arg path) -> signature scripts never pass.
+            assertFalse(vm.execute("PUSH " + sig, locking, 0));
+        }
+
+        @Test
+        @DisplayName("CHECKMULTISIG: 2-of-3 valid with two correct signatures")
+        void checkMultiSig_twoOfThree_valid() {
+            KeyPair k1 = newKeyPair(), k2 = newKeyPair(), k3 = newKeyPair();
+            String locking = multisigLock(2, k1.getPublic(), k2.getPublic(), k3.getPublic());
+
+            String unlocking = "PUSH " + SignatureUtil.sign(k1.getPrivate(), sighash)
+                             + " PUSH " + SignatureUtil.sign(k2.getPrivate(), sighash);
+
+            assertTrue(vm.execute(unlocking, locking, 0, sighash));
+        }
+
+        @Test
+        @DisplayName("CHECKMULTISIG: fewer signatures than the threshold fails")
+        void checkMultiSig_insufficientSignatures_false() {
+            KeyPair k1 = newKeyPair(), k2 = newKeyPair(), k3 = newKeyPair();
+            String locking = multisigLock(2, k1.getPublic(), k2.getPublic(), k3.getPublic());
+
+            // Only one signature supplied against a 2-of-3 lock.
+            String unlocking = "PUSH " + SignatureUtil.sign(k1.getPrivate(), sighash);
+
+            assertFalse(vm.execute(unlocking, locking, 0, sighash));
+        }
+
+        @Test
+        @DisplayName("CHECKMULTISIG: a signature from a non-member key fails")
+        void checkMultiSig_wrongKeySignature_false() {
+            KeyPair k1 = newKeyPair(), k2 = newKeyPair(), k3 = newKeyPair();
+            KeyPair outsider = newKeyPair();
+            String locking = multisigLock(2, k1.getPublic(), k2.getPublic(), k3.getPublic());
+
+            // One valid member signature plus one from a key not in the set.
+            String unlocking = "PUSH " + SignatureUtil.sign(k1.getPrivate(), sighash)
+                             + " PUSH " + SignatureUtil.sign(outsider.getPrivate(), sighash);
+
+            assertFalse(vm.execute(unlocking, locking, 0, sighash));
+        }
+
+        @Test
+        @DisplayName("CHECKMULTISIG: the same signature cannot satisfy two slots")
+        void checkMultiSig_duplicateSignatureNotDoubleCounted() {
+            KeyPair k1 = newKeyPair(), k2 = newKeyPair(), k3 = newKeyPair();
+            String locking = multisigLock(2, k1.getPublic(), k2.getPublic(), k3.getPublic());
+
+            // One member's signature presented twice - distinct-key rule rejects it.
+            String sig1 = SignatureUtil.sign(k1.getPrivate(), sighash);
+            String unlocking = "PUSH " + sig1 + " PUSH " + sig1;
+
+            assertFalse(vm.execute(unlocking, locking, 0, sighash));
+        }
+
+        @Test
+        @DisplayName("Malformed keys, signatures, and counts are false, never a crash")
+        void malformedInput_isFalse_neverThrows() {
+            // Garbage CHECKSIG operands (non-hex pubkey).
+            assertFalse(vm.execute("PUSH deadbeef PUSH nothex CHECKSIG", 0, sighash));
+
+            // Non-numeric N for CHECKMULTISIG.
+            assertFalse(vm.execute("PUSH notanumber CHECKMULTISIG", 0, sighash));
+
+            // Count mismatch: M (3) greater than N (2).
+            KeyPair k1 = newKeyPair(), k2 = newKeyPair();
+            String badCounts = "PUSH 3 PUSH " + SignatureUtil.publicKeyToHex(k1.getPublic())
+                             + " PUSH " + SignatureUtil.publicKeyToHex(k2.getPublic())
+                             + " PUSH 2 CHECKMULTISIG";
+            assertFalse(vm.execute("", badCounts, 0, sighash));
+
+            // Bare opcodes with an empty stack underflow to false.
+            assertFalse(vm.execute("CHECKSIG", 0, sighash));
+            assertFalse(vm.execute("CHECKMULTISIG", 0, sighash));
+        }
+
+        /** Builds an M-of-N lock: {@code M <pub1> ... <pubN> N CHECKMULTISIG}. */
+        private String multisigLock(int m, PublicKey... keys) {
+            StringBuilder sb = new StringBuilder("PUSH ").append(m);
+            for (PublicKey key : keys) {
+                sb.append(" PUSH ").append(SignatureUtil.publicKeyToHex(key));
+            }
+            sb.append(" PUSH ").append(keys.length).append(" CHECKMULTISIG");
+            return sb.toString();
+        }
+    }
+
+    /** Generates a fresh secp256r1 key pair for signature tests. */
+    private KeyPair newKeyPair() {
+        try {
+            KeyPairGenerator keyGen = KeyPairGenerator.getInstance("EC");
+            keyGen.initialize(new ECGenParameterSpec("secp256r1"));
+            return keyGen.generateKeyPair();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to generate key pair", e);
         }
     }
 }


### PR DESCRIPTION
Milestone 15a of Sprint 15 (Multi-signature Wallets). Adds the signature-checking opcodes that let an M-of-N multisig be expressed as a Sprint 14 contract locking script (Bitcoin P2SH-style).

## What changed
- **`SignatureUtil`** (new): ECDSA sign/verify (secp256r1, SHA256withECDSA) + hex encode/decode for public keys (X.509) and signatures (DER). `verify()` returns false on any malformed input rather than throwing - the VM is consensus-critical and must never crash.
- **`ScriptVM.execute(...)`**: new sighash overload. The existing 3-arg and 2-arg forms delegate with an empty sighash, so **every Sprint 14 call site and test is untouched** - signature scripts simply fail without a sighash context (the safe default).
- **`CHECKSIG`**: pop pubkey + signature, push 1 if valid over the sighash.
- **`CHECKMULTISIG`**: Bitcoin bare layout `<sigs> M <pubkeys> N CHECKMULTISIG`; ordered, distinct-key matching, so a duplicate signature cannot satisfy two slots.

## Tests
6 new tests in `ScriptVMTest` (`SignatureOpcodes` group): valid single-sig, 2-of-3 valid, insufficient signatures, wrong-key signature, duplicate-not-double-counted, malformed-never-throws. **Full suite: 220 -> 226, all green.**

Closes #147
Closes #148