### PR TITLE
Sprint 15b: Multisig contracts (M-of-N)

### DIFF
--- a/.ai/sprints/sprint15/sprint-log.md
+++ b/.ai/sprints/sprint15/sprint-log.md
@@ -28,7 +28,25 @@
 
 ---
 
-## Milestone 15b: Multisig contracts (M-of-N) - Pending
+## Milestone 15b: Multisig contracts (M-of-N) - Complete
+
+- `MultiSigWallet` added: holds N member public keys (hex) + threshold M,
+  builds the `CHECKMULTISIG` locking script, and derives a stable `MS:` identity
+  address from that script. Holds public keys only - signing stays with the
+  member key holders. Factories `ofPublicKeys` / `ofHex`.
+- Claim sighash lives on `Contract.claimSighash(claimer)` =
+  `SHA256(contractId + claimer + amount)` - the data lives on the contract, so
+  both the signer and the verifier compute the identical message.
+- A multisig is just a Sprint 14 contract with a signature lock: deploy/claim/
+  registry are unchanged. The ONE wiring change is `Blockchain.isValidClaim`
+  now passing the claim sighash into `scriptVM.execute(...)`; hashlock and
+  timelock contracts ignore it, so nothing from Sprint 14 changes.
+- Replay safety falls out of the sighash: a 2-of-3 set signed for one claimer
+  fails when presented for another (different sighash).
+- 5 new tests in `MultiSigContractTest` (2-of-3 valid, one-sig rejected,
+  wrong-key rejected, replay-to-different-claimer rejected, cross-node
+  convergence). Suite: 226 -> 231, all green.
+- Issues #150 (multisig), #151 (tests).
 
 ---
 

--- a/src/main/java/com/blocksmith/contract/Contract.java
+++ b/src/main/java/com/blocksmith/contract/Contract.java
@@ -1,6 +1,7 @@
 package com.blocksmith.contract;
 
 import com.blocksmith.util.BlockchainConfig;
+import com.blocksmith.util.HashUtil;
 
 /**
  * THEORY: A contract is funds locked behind a script instead of an owner.
@@ -50,6 +51,25 @@ public class Contract {
     /** The chain address holding this contract's locked funds. */
     public String getAddress() {
         return BlockchainConfig.CONTRACT_ADDRESS_PREFIX + contractId;
+    }
+
+    /**
+     * THEORY: THE CLAIM SIGHASH (Sprint 15)
+     *
+     * The message a spender must sign to authorize claiming this contract. It
+     * binds the signature to THIS contract, THIS claimer, and THIS amount, so a
+     * signature set that authorizes "pay Bob" cannot be replayed to "pay Carol"
+     * - the message signed is different. This is exactly why Bitcoin signs a
+     * transaction digest rather than a fixed string.
+     *
+     * Signature scripts (CHECKSIG/CHECKMULTISIG) verify against this value; a
+     * hashlock or timelock contract simply ignores it.
+     *
+     * @param claimer The address the claim would credit
+     * @return The 64-char hex sighash for a claim to {@code claimer}
+     */
+    public String claimSighash(String claimer) {
+        return HashUtil.applySha256(contractId + claimer + amount);
     }
 
     // ===== GETTERS =====

--- a/src/main/java/com/blocksmith/contract/MultiSigWallet.java
+++ b/src/main/java/com/blocksmith/contract/MultiSigWallet.java
@@ -1,0 +1,123 @@
+package com.blocksmith.contract;
+
+import java.security.PublicKey;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import com.blocksmith.util.HashUtil;
+import com.blocksmith.util.SignatureUtil;
+
+/**
+ * THEORY: An M-of-N multisig is just a contract with a signature-checking lock.
+ *
+ * Instead of one key controlling funds, N members hold keys and any M of them
+ * must sign to move the money - a 2-of-3 escrow, a shared treasury, a
+ * backup-key setup. Bitcoin expresses this with a bare multisig script; so do
+ * we, reusing the Sprint 14 contract machinery wholesale:
+ *
+ *   Locking script:  M <pub1> <pub2> ... <pubN> N CHECKMULTISIG
+ *   (as VM tokens)   PUSH M PUSH pub1 ... PUSH pubN PUSH N CHECKMULTISIG
+ *
+ * To spend, a claimer presents M signatures over the claim's sighash
+ * (see {@link Contract#claimSighash}) as the unlocking data:
+ *
+ *   Unlocking data:  PUSH sig1 PUSH sig2   (in member order)
+ *
+ * This wallet holds only PUBLIC keys - it builds the lock and identifies the
+ * member set. Signing is done by whoever holds each member's private key.
+ */
+public class MultiSigWallet {
+
+    /** Prefix for a multisig wallet's stable identity address. */
+    public static final String ADDRESS_PREFIX = "MS:";
+
+    /** Member public keys, hex-encoded (X.509), in signing order. */
+    private final List<String> memberPublicKeys;
+
+    /** Threshold M: the number of signatures required to spend. */
+    private final int threshold;
+
+    private MultiSigWallet(List<String> memberPublicKeys, int threshold) {
+        int n = memberPublicKeys == null ? 0 : memberPublicKeys.size();
+        if (n < 1 || n > ScriptVM.MAX_KEYS) {
+            throw new IllegalArgumentException(
+                    "Member count must be between 1 and " + ScriptVM.MAX_KEYS);
+        }
+        if (threshold < 1 || threshold > n) {
+            throw new IllegalArgumentException(
+                    "Threshold M must be between 1 and the member count N");
+        }
+        for (String key : memberPublicKeys) {
+            if (key == null || key.isBlank()) {
+                throw new IllegalArgumentException("Member public keys must be non-empty");
+            }
+        }
+        this.memberPublicKeys = List.copyOf(memberPublicKeys);
+        this.threshold = threshold;
+    }
+
+    /**
+     * Builds a multisig wallet from member public keys.
+     *
+     * @param members   The N member public keys, in signing order
+     * @param threshold M, the number of signatures required to spend
+     */
+    public static MultiSigWallet ofPublicKeys(List<PublicKey> members, int threshold) {
+        List<String> hex = new ArrayList<>();
+        if (members != null) {
+            for (PublicKey key : members) {
+                hex.add(key == null ? null : SignatureUtil.publicKeyToHex(key));
+            }
+        }
+        return new MultiSigWallet(hex, threshold);
+    }
+
+    /**
+     * Builds a multisig wallet from hex-encoded member public keys.
+     *
+     * @param memberPublicKeysHex The N member public keys as hex, in order
+     * @param threshold           M, the number of signatures required
+     */
+    public static MultiSigWallet ofHex(List<String> memberPublicKeysHex, int threshold) {
+        return new MultiSigWallet(memberPublicKeysHex, threshold);
+    }
+
+    /**
+     * Builds the CHECKMULTISIG locking script guarding this wallet's funds:
+     * {@code PUSH M PUSH pub1 ... PUSH pubN PUSH N CHECKMULTISIG}.
+     */
+    public String getLockingScript() {
+        StringBuilder script = new StringBuilder("PUSH ").append(threshold);
+        for (String key : memberPublicKeys) {
+            script.append(" PUSH ").append(key);
+        }
+        script.append(" PUSH ").append(memberPublicKeys.size()).append(" CHECKMULTISIG");
+        return script.toString();
+    }
+
+    /**
+     * A stable identity address for this member set + threshold, derived from
+     * the locking script. Two wallets with the same members and threshold share
+     * an address; note the actual funds live in a per-deploy CONTRACT:&lt;id&gt;
+     * address, not here.
+     */
+    public String getAddress() {
+        return ADDRESS_PREFIX + HashUtil.applySha256(getLockingScript());
+    }
+
+    /** @return M, the number of signatures required to spend. */
+    public int getThreshold() {
+        return threshold;
+    }
+
+    /** @return N, the number of member keys. */
+    public int getMemberCount() {
+        return memberPublicKeys.size();
+    }
+
+    /** @return the member public keys, hex-encoded, in signing order. */
+    public List<String> getMemberPublicKeys() {
+        return Collections.unmodifiableList(memberPublicKeys);
+    }
+}

--- a/src/main/java/com/blocksmith/core/Blockchain.java
+++ b/src/main/java/com/blocksmith/core/Blockchain.java
@@ -518,8 +518,13 @@ public class Blockchain {
         }
 
         // The claim height is the index the NEXT block will have - the
-        // earliest height the claim could be mined at (CHECKLOCKTIME).
-        if (!scriptVM.execute(claim.getUnlockingScript(), contract.getLockingScript(), chain.size())) {
+        // earliest height the claim could be mined at (CHECKLOCKTIME). The
+        // sighash binds any signature in the unlocking data to THIS claim
+        // (contract + claimer + amount), so a multisig CHECKMULTISIG can verify
+        // it; hashlock/timelock scripts ignore the sighash.
+        String sighash = contract.claimSighash(claim.getRecipient());
+        if (!scriptVM.execute(claim.getUnlockingScript(), contract.getLockingScript(),
+                chain.size(), sighash)) {
             System.out.println("Claim rejected: Script evaluated to false");
             return false;
         }

--- a/src/test/java/com/blocksmith/contract/MultiSigContractTest.java
+++ b/src/test/java/com/blocksmith/contract/MultiSigContractTest.java
@@ -1,0 +1,178 @@
+package com.blocksmith.contract;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.blocksmith.core.Blockchain;
+import com.blocksmith.core.Transaction;
+import com.blocksmith.util.BlockchainConfig;
+import com.blocksmith.util.SignatureUtil;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.spec.ECGenParameterSpec;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for multisig contracts (Milestone 15b): an M-of-N multisig is a
+ * contract whose lock is a CHECKMULTISIG, spent by presenting M signatures over
+ * the claim sighash. Reuses the Sprint 14 deploy/claim/registry unchanged, so
+ * these tests focus on the signature semantics and replay safety.
+ */
+@DisplayName("Multisig Contract Tests")
+class MultiSigContractTest {
+
+    private static final String FUNDER = "funder-address";
+    private static final String CLAIMER = "claimer-address";
+    private static final String MINER = "miner-address";
+
+    private Blockchain blockchain;
+    private KeyPair k1, k2, k3;
+
+    @BeforeEach
+    void setUp() {
+        blockchain = new Blockchain();
+        // Fund the funder with a mining reward (50 BSC).
+        blockchain.minePendingTransactions(FUNDER);
+
+        k1 = newKeyPair();
+        k2 = newKeyPair();
+        k3 = newKeyPair();
+    }
+
+    @Test
+    @DisplayName("2-of-3: a claim with two valid signatures credits the claimer")
+    void twoOfThree_claimWithTwoSignatures_creditsClaimer() {
+        String id = deployMultisig(2, 20);
+
+        String unlocking = signatures(id, CLAIMER, k1, k2);
+        Transaction claim = blockchain.claimContract(id, CLAIMER, unlocking);
+        assertNotNull(claim, "Two valid member signatures should unlock the contract");
+
+        blockchain.minePendingTransactions(MINER);
+
+        assertEquals(20, blockchain.getBalance(CLAIMER), 0.0001);
+        assertEquals(ContractStatus.CLAIMED, blockchain.getContract(id).getStatus());
+        assertEquals(CLAIMER, blockchain.getContract(id).getClaimer());
+    }
+
+    @Test
+    @DisplayName("2-of-3: a single signature is below the threshold and rejected")
+    void claimWithOneSignature_rejected() {
+        String id = deployMultisig(2, 20);
+
+        String unlocking = signatures(id, CLAIMER, k1);
+        assertNull(blockchain.claimContract(id, CLAIMER, unlocking),
+                "One signature cannot satisfy a 2-of-3 lock");
+
+        assertEquals(0, blockchain.getBalance(CLAIMER), 0.0001);
+        assertEquals(ContractStatus.OPEN, blockchain.getContract(id).getStatus());
+        assertEquals(0, blockchain.getPendingCount());
+    }
+
+    @Test
+    @DisplayName("2-of-3: a signature from a non-member key is rejected")
+    void claimWithWrongKeySignature_rejected() {
+        String id = deployMultisig(2, 20);
+
+        // One valid member signature plus one from a key not in the set.
+        KeyPair outsider = newKeyPair();
+        String unlocking = signatures(id, CLAIMER, k1, outsider);
+        assertNull(blockchain.claimContract(id, CLAIMER, unlocking),
+                "A non-member signature must not count toward the threshold");
+
+        assertEquals(0, blockchain.getBalance(CLAIMER), 0.0001);
+        assertEquals(ContractStatus.OPEN, blockchain.getContract(id).getStatus());
+    }
+
+    @Test
+    @DisplayName("Signatures authorizing one claimer cannot be replayed for another")
+    void signatureReplayToDifferentClaimer_rejected() {
+        String id = deployMultisig(2, 20);
+
+        // Two valid signatures, but signed over CLAIMER's sighash.
+        String unlocking = signatures(id, CLAIMER, k1, k2);
+
+        // Presenting them to pay a DIFFERENT claimer changes the sighash, so
+        // the signatures no longer verify.
+        assertNull(blockchain.claimContract(id, "0xcarol", unlocking),
+                "A signature for one claimer must not authorize another");
+
+        assertEquals(0, blockchain.getBalance("0xcarol"), 0.0001);
+        assertEquals(ContractStatus.OPEN, blockchain.getContract(id).getStatus());
+
+        // The intended claimer can still spend with the same signatures.
+        assertNotNull(blockchain.claimContract(id, CLAIMER, unlocking));
+    }
+
+    @Test
+    @DisplayName("External blocks build the same multisig state (network convergence)")
+    void externalBlocks_buildSameMultisigState() {
+        Blockchain nodeB = new Blockchain();
+
+        String id = deployMultisig(2, 20);
+        blockchain.claimContract(id, CLAIMER, signatures(id, CLAIMER, k1, k2));
+        blockchain.minePendingTransactions(MINER);
+
+        // Replay A's mined blocks (skip the shared genesis) onto B.
+        for (int i = 1; i < blockchain.getChainSize(); i++) {
+            assertTrue(nodeB.addBlock(blockchain.getBlock(i)),
+                    "Block " + i + " should append cleanly on node B");
+        }
+
+        Contract onB = nodeB.getContract(id);
+        assertNotNull(onB, "Node B should derive the multisig contract from the blocks");
+        assertEquals(ContractStatus.CLAIMED, onB.getStatus());
+        assertEquals(CLAIMER, onB.getClaimer());
+        assertEquals(20, nodeB.getBalance(CLAIMER), 0.0001);
+    }
+
+    // ===== HELPERS =====
+
+    /**
+     * Deploys an M-of-3 multisig over {@code k1,k2,k3} and mines it OPEN.
+     *
+     * @return the contract id
+     */
+    private String deployMultisig(int threshold, double amount) {
+        MultiSigWallet wallet = MultiSigWallet.ofPublicKeys(
+                List.of(k1.getPublic(), k2.getPublic(), k3.getPublic()), threshold);
+        Transaction deploy = blockchain.deployContract(FUNDER, wallet.getLockingScript(), amount);
+        assertNotNull(deploy, "Deploy within balance should be accepted");
+        blockchain.minePendingTransactions(MINER);
+        return deploy.getRecipient()
+                .substring(BlockchainConfig.CONTRACT_ADDRESS_PREFIX.length());
+    }
+
+    /**
+     * Builds an unlocking script of signatures over the claim's sighash, in the
+     * given key order: {@code PUSH sig1 PUSH sig2 ...}.
+     */
+    private String signatures(String contractId, String claimer, KeyPair... signers) {
+        String sighash = blockchain.getContract(contractId).claimSighash(claimer);
+        StringBuilder unlocking = new StringBuilder();
+        for (KeyPair signer : signers) {
+            if (unlocking.length() > 0) unlocking.append(' ');
+            unlocking.append("PUSH ").append(sign(signer.getPrivate(), sighash));
+        }
+        return unlocking.toString();
+    }
+
+    private String sign(PrivateKey privateKey, String message) {
+        return SignatureUtil.sign(privateKey, message);
+    }
+
+    private KeyPair newKeyPair() {
+        try {
+            KeyPairGenerator keyGen = KeyPairGenerator.getInstance("EC");
+            keyGen.initialize(new ECGenParameterSpec("secp256r1"));
+            return keyGen.generateKeyPair();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to generate key pair", e);
+        }
+    }
+}


### PR DESCRIPTION
Milestone 15b of Sprint 15. An M-of-N multisig is just a Sprint 14 contract whose lock is a `CHECKMULTISIG` (Bitcoin bare-multisig style), spent by presenting M signatures over the claim sighash.

## What changed
- **`MultiSigWallet`** (new): holds N member public keys (hex) + threshold M; builds the `CHECKMULTISIG` locking script `PUSH M PUSH pub1 ... PUSH pubN PUSH N CHECKMULTISIG`; derives a stable `MS:` identity address from that script. Holds **public keys only** - signing stays with the member key holders. Factories `ofPublicKeys` / `ofHex`.
- **`Contract.claimSighash(claimer)`** = `SHA256(contractId + claimer + amount)`. The sighash lives on the contract, so signer and verifier compute the **identical** message - no formatting drift.
- **One wiring change**: `Blockchain.isValidClaim` now feeds the claim sighash into `scriptVM.execute(...)`. Hashlock and timelock contracts ignore it, so **all of Sprint 14 is untouched** - a multisig reuses deploy/claim/registry wholesale.

## Replay safety
The sighash binds a signature to one claim: a 2-of-3 set authorizing "pay CLAIMER" fails when presented to pay someone else, because the sighash (and thus the message signed) differs.

## Tests
5 new tests in `MultiSigContractTest`: 2-of-3 valid, one-signature rejected, wrong-key rejected, replay-to-different-claimer rejected, cross-node convergence. **Full suite: 226 -> 231, all green** (every Sprint 14 contract test still passes through the new sighash path).

Closes #150
Closes #151