### PR TITLE
Sprint 15c: Multisig API endpoints + dashboard panel

### DIFF
--- a/.ai/sprints/sprint15/sprint-log.md
+++ b/.ai/sprints/sprint15/sprint-log.md
@@ -50,7 +50,28 @@
 
 ---
 
-## Milestone 15c: API + dashboard integration - Pending
+## Milestone 15c: API + dashboard integration - Complete
+
+- `POST /api/multisig/create` (members N + threshold M): the node generates the
+  N member key pairs, keeps the private keys server-side, and returns only the
+  address, member public keys, and CHECKMULTISIG locking script. Private keys
+  are NEVER serialized (verified live: no `privateKey` field in the response).
+- `POST /api/multisig/claim` (contractId + claimer): the node looks up the
+  member keys it holds for the contract's lock, signs the claim sighash with
+  the first M, assembles `PUSH sig1 ... PUSH sigM`, and submits the claim. This
+  is the educational server-side signing convenience, flagged as such and
+  consistent with the unsigned transaction endpoints from Sprint 12.
+- Member keys are stored in `ApiServer.multisigSessions`, keyed by locking
+  script, so a claim finds its keys from the contract alone.
+- Dashboard: a new Multisig panel creates a wallet (and hands the lock to the
+  Deploy form) and claims from a contract id; errors surface inline. Reuses the
+  existing action styles - no CSS change.
+- 2 new server tests in `ApiMultiSigTest` (full HTTP lifecycle; rejection
+  envelopes). Suite: 231 -> 233, all green.
+- Verified LIVE against a running node: create -> deploy -> mine -> claim ->
+  mine credited the claimer 20 BSC and closed the contract CLAIMED; rejections
+  returned a 400 error envelope; the dashboard serves the panel.
+- Issues #153 (endpoints/UI), #154 (tests).
 
 ---
 

--- a/src/main/java/com/blocksmith/api/ApiServer.java
+++ b/src/main/java/com/blocksmith/api/ApiServer.java
@@ -1,16 +1,24 @@
 package com.blocksmith.api;
 
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.spec.ECGenParameterSpec;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 import com.blocksmith.contract.Contract;
+import com.blocksmith.contract.MultiSigWallet;
+import com.blocksmith.contract.ScriptVM;
 import com.blocksmith.core.Block;
 import com.blocksmith.core.Blockchain;
 import com.blocksmith.core.Transaction;
 import com.blocksmith.core.Wallet;
 import com.blocksmith.util.BlockchainConfig;
+import com.blocksmith.util.SignatureUtil;
 import com.blocksmith.network.NetworkConfig;
 import com.blocksmith.network.Node;
 import com.blocksmith.network.PeerInfo;
@@ -44,6 +52,21 @@ public class ApiServer {
     private final Blockchain blockchain;
     private final int port;
     private final Gson gson = new Gson();
+
+    /**
+     * Server-held member keys for multisig wallets created via the API, keyed
+     * by locking script.
+     *
+     * EDUCATIONAL CONVENIENCE: a real wallet signs client-side and the node
+     * never sees a private key. For this demo the node generates the member
+     * keys and signs claims on the user's behalf - the same trade-off the
+     * unsigned transaction endpoints already make. The private keys live here
+     * in memory and are NEVER serialized over the API.
+     */
+    private final Map<String, MultiSigSession> multisigSessions = new LinkedHashMap<>();
+
+    /** A multisig wallet plus the member private keys the node holds for it. */
+    private record MultiSigSession(MultiSigWallet wallet, List<PrivateKey> memberKeys) {}
 
     private Javalin app;
 
@@ -105,6 +128,10 @@ public class ApiServer {
         app.get("/api/contracts/{id}", this::getContract);
         app.post("/api/contracts", this::postContract);
         app.post("/api/contracts/{id}/claim", this::postContractClaim);
+
+        // Multisig endpoints (Milestone 15c).
+        app.post("/api/multisig/create", this::postMultiSigCreate);
+        app.post("/api/multisig/claim", this::postMultiSigClaim);
 
         // JSON error handling (Milestone 12c).
         app.exception(Exception.class, (e, ctx) -> {
@@ -367,6 +394,133 @@ public class ApiServer {
         m.put("status", contract.getStatus().toString());
         m.put("claimer", contract.getClaimer());
         return m;
+    }
+
+    // ===== 15c: MULTISIG =====
+
+    /**
+     * Creates an M-of-N multisig wallet. The node generates the N member key
+     * pairs, keeps the private keys server-side (see {@link #multisigSessions}),
+     * and returns only public data: the wallet address, the member public keys,
+     * and the CHECKMULTISIG locking script to deploy with.
+     */
+    private void postMultiSigCreate(Context ctx) {
+        JsonObject body;
+        try {
+            body = JsonParser.parseString(ctx.body()).getAsJsonObject();
+        } catch (JsonSyntaxException | IllegalStateException e) {
+            ctx.status(400);
+            json(ctx, error("Request body must be a JSON object"));
+            return;
+        }
+
+        if (!body.has("members") || !body.has("threshold")) {
+            ctx.status(400);
+            json(ctx, error("Multisig requires members (N) and threshold (M)"));
+            return;
+        }
+
+        int n = body.get("members").getAsInt();
+        int m = body.get("threshold").getAsInt();
+        if (n < 1 || n > ScriptVM.MAX_KEYS || m < 1 || m > n) {
+            ctx.status(400);
+            json(ctx, error("Require 1 <= threshold <= members <= " + ScriptVM.MAX_KEYS));
+            return;
+        }
+
+        // Generate the member key pairs; keep privates server-side, publish publics.
+        List<PublicKey> publicKeys = new ArrayList<>();
+        List<PrivateKey> privateKeys = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            KeyPair kp = generateKeyPair();
+            publicKeys.add(kp.getPublic());
+            privateKeys.add(kp.getPrivate());
+        }
+
+        MultiSigWallet wallet = MultiSigWallet.ofPublicKeys(publicKeys, m);
+        multisigSessions.put(wallet.getLockingScript(),
+                new MultiSigSession(wallet, privateKeys));
+
+        Map<String, Object> out = new LinkedHashMap<>();
+        out.put("address", wallet.getAddress());
+        out.put("threshold", wallet.getThreshold());
+        out.put("memberCount", wallet.getMemberCount());
+        out.put("memberPublicKeys", wallet.getMemberPublicKeys());
+        out.put("lockingScript", wallet.getLockingScript());
+        ctx.status(201);
+        json(ctx, out);
+    }
+
+    /**
+     * Assembles and submits a claim against a multisig contract. Given the
+     * contract id and the claimer, the node looks up the member keys it holds
+     * for that contract's lock, signs the claim sighash with the first M of
+     * them, and submits the assembled claim - the signing convenience noted on
+     * {@link #multisigSessions}.
+     */
+    private void postMultiSigClaim(Context ctx) {
+        JsonObject body;
+        try {
+            body = JsonParser.parseString(ctx.body()).getAsJsonObject();
+        } catch (JsonSyntaxException | IllegalStateException e) {
+            ctx.status(400);
+            json(ctx, error("Request body must be a JSON object"));
+            return;
+        }
+
+        if (!body.has("contractId") || !body.has("claimer")) {
+            ctx.status(400);
+            json(ctx, error("Multisig claim requires contractId and claimer"));
+            return;
+        }
+
+        String contractId = body.get("contractId").getAsString();
+        String claimer = body.get("claimer").getAsString();
+
+        Contract contract = blockchain.getContract(contractId);
+        if (contract == null) {
+            ctx.status(400);
+            json(ctx, error("Unknown contract (the deploy may not be mined yet)"));
+            return;
+        }
+
+        MultiSigSession session = multisigSessions.get(contract.getLockingScript());
+        if (session == null) {
+            ctx.status(400);
+            json(ctx, error("No server-held keys for this contract's multisig"));
+            return;
+        }
+
+        // Sign the claim sighash with the first M member keys, in member order.
+        String sighash = contract.claimSighash(claimer);
+        StringBuilder unlocking = new StringBuilder();
+        for (int i = 0; i < session.wallet().getThreshold(); i++) {
+            if (unlocking.length() > 0) unlocking.append(' ');
+            unlocking.append("PUSH ").append(
+                    SignatureUtil.sign(session.memberKeys().get(i), sighash));
+        }
+
+        Transaction claim = blockchain.claimContract(contractId, claimer, unlocking.toString());
+        if (claim == null) {
+            ctx.status(400);
+            json(ctx, error("Multisig claim rejected (unknown/claimed contract or signatures failed)"));
+            return;
+        }
+
+        node.broadcastTransaction(claim);
+        ctx.status(201);
+        json(ctx, contractInfo(contract));
+    }
+
+    /** Generates a secp256r1 key pair for a server-held multisig member. */
+    private KeyPair generateKeyPair() {
+        try {
+            KeyPairGenerator keyGen = KeyPairGenerator.getInstance("EC");
+            keyGen.initialize(new ECGenParameterSpec("secp256r1"));
+            return keyGen.generateKeyPair();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to generate key pair", e);
+        }
     }
 
     private void getBlockByIndex(Context ctx) {

--- a/src/main/resources/public/app.js
+++ b/src/main/resources/public/app.js
@@ -222,6 +222,31 @@ function wireActions() {
             return "Claim submitted for " + shortHash(contract.contractId) + " (mine to settle)";
         });
     });
+
+    document.getElementById("ms-create").addEventListener("click", function () {
+        runAction("ms-create-result", async function () {
+            const wallet = await postJson("/api/multisig/create", {
+                members: Number(document.getElementById("ms-members").value),
+                threshold: Number(document.getElementById("ms-threshold").value)
+            });
+            // Hand the lock straight to the Deploy form so it can be funded.
+            document.getElementById("deploy-script").value = wallet.lockingScript;
+            return "Created " + wallet.threshold + "-of-" + wallet.memberCount
+                + " multisig " + shortHash(wallet.address) + " (deploy the lock to fund it)";
+        });
+    });
+
+    document.getElementById("ms-claim").addEventListener("click", function () {
+        runAction("ms-claim-result", async function () {
+            const id = document.getElementById("ms-claim-id").value.trim();
+            if (!id) throw new Error("Enter a contract id to claim");
+            const contract = await postJson("/api/multisig/claim", {
+                contractId: id,
+                claimer: document.getElementById("ms-claim-claimer").value.trim()
+            });
+            return "Multisig claim submitted for " + shortHash(contract.contractId) + " (mine to settle)";
+        });
+    });
 }
 
 async function refresh() {

--- a/src/main/resources/public/index.html
+++ b/src/main/resources/public/index.html
@@ -74,6 +74,28 @@
             <div id="contract-list"></div>
         </section>
 
+        <section id="multisig">
+            <h2>Multisig</h2>
+            <p class="muted">M-of-N wallets. The node generates the member keys and signs on your behalf (educational convenience; a real wallet signs client-side).</p>
+            <div class="action-grid">
+                <div class="action">
+                    <h3>Create wallet</h3>
+                    <input id="ms-members" type="number" placeholder="members (N)" min="1" step="1" autocomplete="off">
+                    <input id="ms-threshold" type="number" placeholder="threshold (M)" min="1" step="1" autocomplete="off">
+                    <button id="ms-create">Create multisig</button>
+                    <p id="ms-create-result" class="action-result"></p>
+                </div>
+
+                <div class="action">
+                    <h3>Claim</h3>
+                    <input id="ms-claim-id" type="text" placeholder="contract id" autocomplete="off">
+                    <input id="ms-claim-claimer" type="text" placeholder="claimer address" autocomplete="off">
+                    <button id="ms-claim">Claim multisig</button>
+                    <p id="ms-claim-result" class="action-result"></p>
+                </div>
+            </div>
+        </section>
+
         <section id="blocks">
             <h2>Blocks</h2>
             <div id="block-list"></div>

--- a/src/test/java/com/blocksmith/api/ApiMultiSigTest.java
+++ b/src/test/java/com/blocksmith/api/ApiMultiSigTest.java
@@ -1,0 +1,143 @@
+package com.blocksmith.api;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.blocksmith.network.Node;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Server-side tests for the Milestone 15c multisig endpoints. Drives the same
+ * HTTP chain the dashboard's Multisig panel hits - create a wallet, deploy its
+ * lock as a contract, mine, claim with the node's assembled signatures, mine -
+ * and confirms funds move and rejections carry an error envelope.
+ */
+@DisplayName("API Multisig Tests")
+class ApiMultiSigTest {
+
+    private static final int API_PORT_BASE = 17700;
+    private static final int P2P_PORT_BASE = 19200;
+    private static int counter = 0;
+
+    private static final String FUNDER = "funder-address";
+    private static final String CLAIMER = "claimer-address";
+    private static final String MINER = "miner-address";
+
+    private Node node;
+    private ApiServer api;
+    private int apiPort;
+    private final HttpClient client = HttpClient.newHttpClient();
+
+    @BeforeEach
+    void setUp() {
+        int offset = counter++;
+        apiPort = API_PORT_BASE + offset;
+        node = new Node(P2P_PORT_BASE + offset);
+        api = new ApiServer(node, apiPort);
+        api.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (api != null) api.stop();
+        if (node != null) node.stop();
+    }
+
+    private HttpResponse<String> get(String path) throws Exception {
+        return client.send(
+                HttpRequest.newBuilder()
+                        .uri(URI.create("http://localhost:" + apiPort + path))
+                        .GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    private HttpResponse<String> post(String path, String body) throws Exception {
+        return client.send(
+                HttpRequest.newBuilder()
+                        .uri(URI.create("http://localhost:" + apiPort + path))
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString(body))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    private static JsonObject json(HttpResponse<String> res) {
+        return JsonParser.parseString(res.body()).getAsJsonObject();
+    }
+
+    private void mineTo(String address) throws Exception {
+        post("/api/mine", "{\"minerAddress\":\"" + address + "\"}");
+    }
+
+    @Test
+    @DisplayName("Multisig lifecycle over HTTP: create, deploy, mine, claim, settle")
+    void multisigLifecycle_overHttp() throws Exception {
+        // Give the funder a mining reward to lock.
+        mineTo(FUNDER);
+
+        // Create a 2-of-3 multisig; the node holds the member keys.
+        HttpResponse<String> created = post("/api/multisig/create",
+                "{\"members\":3,\"threshold\":2}");
+        assertEquals(201, created.statusCode());
+        JsonObject wallet = json(created);
+        assertEquals(2, wallet.get("threshold").getAsInt());
+        assertEquals(3, wallet.get("memberCount").getAsInt());
+        assertEquals(3, wallet.getAsJsonArray("memberPublicKeys").size());
+        // The private keys must never be exposed.
+        assertFalse(created.body().contains("privateKey"));
+        String lockingScript = wallet.get("lockingScript").getAsString();
+
+        // Deploy the multisig lock as a contract.
+        String deployBody = "{\"funder\":\"" + FUNDER + "\",\"amount\":20,"
+                + "\"lockingScript\":\"" + lockingScript + "\"}";
+        HttpResponse<String> deployed = post("/api/contracts", deployBody);
+        assertEquals(201, deployed.statusCode());
+        String contractId = json(deployed).get("contractId").getAsString();
+
+        // Mine the deploy: the contract becomes OPEN.
+        mineTo(MINER);
+        assertEquals("OPEN", json(get("/api/contracts/" + contractId)).get("status").getAsString());
+
+        // Claim via the multisig endpoint: the node assembles the M signatures.
+        HttpResponse<String> claimed = post("/api/multisig/claim",
+                "{\"contractId\":\"" + contractId + "\",\"claimer\":\"" + CLAIMER + "\"}");
+        assertEquals(201, claimed.statusCode());
+
+        // Mine to settle, then verify the funds moved and the contract closed.
+        mineTo(MINER);
+        assertEquals("CLAIMED", json(get("/api/contracts/" + contractId)).get("status").getAsString());
+        assertEquals(20.0, json(get("/api/wallet/" + CLAIMER)).get("balance").getAsDouble(), 0.0001,
+                "Claimer should receive the locked amount once settled");
+    }
+
+    @Test
+    @DisplayName("Rejected multisig create and claim return an error envelope")
+    void rejectedMultisigClaim_returnsErrorEnvelope() throws Exception {
+        // Claim an unknown contract -> 400 + error.
+        HttpResponse<String> unknown = post("/api/multisig/claim",
+                "{\"contractId\":\"nope\",\"claimer\":\"" + CLAIMER + "\"}");
+        assertEquals(400, unknown.statusCode());
+        assertTrue(json(unknown).has("error"));
+
+        // Missing threshold on create -> 400 + error.
+        HttpResponse<String> missing = post("/api/multisig/create", "{\"members\":3}");
+        assertEquals(400, missing.statusCode());
+        assertTrue(json(missing).has("error"));
+
+        // Threshold greater than the member count -> 400 + error.
+        HttpResponse<String> badThreshold = post("/api/multisig/create",
+                "{\"members\":2,\"threshold\":5}");
+        assertEquals(400, badThreshold.statusCode());
+        assertTrue(json(badThreshold).has("error"));
+    }
+}


### PR DESCRIPTION
Milestone 15c of Sprint 15 - the finale. Exposes multisig over HTTP and the dashboard, completing the sprint and Phase 3.

## Endpoints
- **`POST /api/multisig/create`** `{members, threshold}` - the node generates the N member key pairs, keeps the **private keys server-side**, and returns only the address, member public keys, and the `CHECKMULTISIG` locking script. Private keys are **never serialized** (verified live: no `privateKey` field in the response).
- **`POST /api/multisig/claim`** `{contractId, claimer}` - the node looks up the member keys it holds for the contract's lock, signs the claim sighash with the first M, assembles `PUSH sig1 ... PUSH sigM`, and submits the claim.

Server-side signing is an **educational convenience**, clearly flagged, consistent with the unsigned transaction endpoints from Sprint 12. Member keys live in `ApiServer.multisigSessions`, keyed by locking script, so a claim finds its keys from the contract alone.

## Dashboard
A new **Multisig panel**: create a wallet (which hands the lock straight to the Deploy form to fund it) and claim from a contract id. Errors surface inline. Reuses existing action styles - no CSS change.

## Tests + live verification
- 2 new tests in `ApiMultiSigTest`: full HTTP lifecycle (create -> deploy -> mine -> claim -> mine -> balances move) and rejection envelopes. **Suite: 231 -> 233, all green.**
- **Verified live** against a running node: the full lifecycle credited the claimer 20 BSC and closed the contract `CLAIMED`; unknown-contract and bad-threshold requests returned `400` + error envelope; the dashboard serves the panel.

Closes #153
Closes #154